### PR TITLE
feat: Fix Unbounded Data Growth with Retention Policies (Issue #19)

### DIFF
--- a/dashboard/backend/CHANGELOG.md
+++ b/dashboard/backend/CHANGELOG.md
@@ -7,7 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **Data retention policies and cleanup jobs** (Issue #19):
+  - New `cleanup-old-records.job.ts`: Scheduled job to clean up old data records daily at 2 AM UTC
+  - OddsSnapshot records: 30-day retention policy (automatically deleted after 30 days)
+  - ApiKeyUsage records: 90-day retention policy (automatically deleted after 90 days)
+  - Prevents unbounded data growth in database
+
 ### Fixed
+- **OddsSnapshot table missing index** (schema.prisma): Added index on capturedAt field
+  - Improves query performance when filtering/deleting by captured timestamp
+  - Supports retention policy cleanup queries
 - **Site config PUT lacks Zod validation** (admin.routes.ts): Added URL validation using Zod schema with `.url()` validator
   for logoUrl and domainUrl fields to prevent XSS attacks via malicious URLs
 - **Force delete bypass authorization** (bets.routes.ts): Added admin authorization check for force delete query parameter

--- a/dashboard/backend/prisma/schema.prisma
+++ b/dashboard/backend/prisma/schema.prisma
@@ -268,6 +268,8 @@ model OddsSnapshot {
   capturedAt      DateTime @default(now()) @map("captured_at") @db.Timestamptz(6)
   game            Game     @relation(fields: [gameId], references: [id], onDelete: Cascade)
 
+  @@index([capturedAt])
+  @@index([gameId])
   @@map("odds_snapshots")
 }
 

--- a/dashboard/backend/src/jobs/cleanup-old-records.job.ts
+++ b/dashboard/backend/src/jobs/cleanup-old-records.job.ts
@@ -1,0 +1,118 @@
+import cron from 'node-cron';
+import { prisma } from '../config/database';
+import { logger } from '../config/logger';
+
+/**
+ * Scheduled job to clean up old data records
+ * 
+ * Removes:
+ * - OddsSnapshot records older than 30 days
+ * - ApiKeyUsage records older than 90 days
+ * 
+ * Runs daily at 2 AM UTC
+ */
+
+const CLEANUP_CRON_EXPRESSION = '0 2 * * *'; // 2 AM UTC daily
+
+let isRunning = false;
+let lastRunTime: Date | null = null;
+
+/**
+ * Delete old odds snapshots (30-day retention)
+ */
+async function deleteOldOddsSnapshots() {
+  const thirtyDaysAgo = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000);
+  
+  try {
+    const result = await prisma.oddsSnapshot.deleteMany({
+      where: {
+        capturedAt: {
+          lt: thirtyDaysAgo
+        }
+      }
+    });
+    
+    logger.info(`📊 Deleted ${result.count} old odds snapshots (older than 30 days)`);
+    return result.count;
+  } catch (error) {
+    logger.error('Failed to delete old odds snapshots:', error);
+    throw error;
+  }
+}
+
+/**
+ * Delete old API key usage records (90-day retention)
+ */
+async function deleteOldApiKeyUsage() {
+  const ninetyDaysAgo = new Date(Date.now() - 90 * 24 * 60 * 60 * 1000);
+  
+  try {
+    const result = await prisma.apiKeyUsage.deleteMany({
+      where: {
+        createdAt: {
+          lt: ninetyDaysAgo
+        }
+      }
+    });
+    
+    logger.info(`🔐 Deleted ${result.count} old API key usage records (older than 90 days)`);
+    return result.count;
+  } catch (error) {
+    logger.error('Failed to delete old API key usage records:', error);
+    throw error;
+  }
+}
+
+/**
+ * Execute cleanup tasks
+ */
+async function executeCleanup() {
+  if (isRunning) {
+    logger.warn('Data cleanup already in progress, skipping...');
+    return;
+  }
+
+  isRunning = true;
+  lastRunTime = new Date();
+
+  try {
+    logger.info('='.repeat(60));
+    logger.info('Starting scheduled data cleanup...');
+    
+    const startTime = Date.now();
+    
+    const oddsSnapshotsDeleted = await deleteOldOddsSnapshots();
+    const apiKeyUsageDeleted = await deleteOldApiKeyUsage();
+    
+    const duration = Date.now() - startTime;
+
+    logger.info(`✅ Data cleanup completed successfully in ${duration}ms`);
+    logger.info(`   OddsSnapshots deleted: ${oddsSnapshotsDeleted}`);
+    logger.info(`   ApiKeyUsage deleted: ${apiKeyUsageDeleted}`);
+    logger.info('='.repeat(60));
+  } catch (error) {
+    logger.error('❌ Data cleanup failed:', error);
+  } finally {
+    isRunning = false;
+  }
+}
+
+/**
+ * Initialize cleanup job
+ */
+export function initializeCleanupJob() {
+  logger.info(`Scheduling cleanup job to run at: ${CLEANUP_CRON_EXPRESSION} (2 AM UTC)`);
+  cron.schedule(CLEANUP_CRON_EXPRESSION, executeCleanup, {
+    runOnInit: false
+  });
+}
+
+/**
+ * Get cleanup job status
+ */
+export function getCleanupStatus() {
+  return {
+    isRunning,
+    lastRunTime
+  };
+}

--- a/dashboard/backend/src/server.ts
+++ b/dashboard/backend/src/server.ts
@@ -7,6 +7,7 @@ import { startOddsSyncJob } from './jobs/sync-odds.job';
 import { startSettleBetsJob } from './jobs/settle-bets.job';
 import { startStatsSyncJob } from './jobs/stats-sync.job';
 import { startClosingLineCaptureJob } from './jobs/capture-closing-lines.job';
+import { initializeCleanupJob } from './jobs/cleanup-old-records.job';
 
 const PORT = parseInt(env.PORT, 10);
 
@@ -32,6 +33,7 @@ async function startServer() {
       startSettleBetsJob();
       startStatsSyncJob();
       startClosingLineCaptureJob();
+      initializeCleanupJob();
       logger.info('✅ Scheduled jobs started');
     } catch (error) {
       logger.error('Failed to start scheduled jobs:', error);


### PR DESCRIPTION
## Summary
Implements data retention policies and automated cleanup jobs to prevent unbounded data growth in OddsSnapshot and ApiKeyUsage tables.

## Issues Addressed

### 1. OddsSnapshot Table Unbounded Growth
**Problem**: ~13,500 new rows per hour, no retention policy, no performance indices
- Odds API integration captures snapshots for every odds update across all games and bookmakers
- Without active cleanup, historical snapshots accumulate indefinitely
- Database size grows rapidly, query performance degrades

**Solution**:
- Added `capturedAt` index to OddsSnapshot model for efficient time-based queries
- Implemented 30-day retention policy via cleanup job
- Automatic deletion of snapshots older than 30 days

### 2. ApiKeyUsage Table Unbounded Growth  
**Problem**: Tens of thousands of rows per day, no cleanup mechanism
- User API key usage is logged for every request (endpoint, method, IP, user agent)
- Usage data grows continuously for operational tracking and analytics
- No mechanism to prevent indefinite growth

**Solution**:
- Implemented 90-day retention policy via cleanup job
- Automatic deletion of API usage logs older than 90 days
- Retains recent usage for analytics without unbounded storage

## Implementation Details

### 1. Database Schema Changes
**File**: `dashboard/backend/prisma/schema.prisma`
- Added index on `OddsSnapshot.capturedAt` for efficient filtering by timestamp
- ApiKeyUsage already has index on `createdAt`, no changes needed

### 2. Cleanup Job
**File**: `dashboard/backend/src/jobs/cleanup-old-records.job.ts`
- New scheduled job that runs daily at 2 AM UTC (cron: `0 2 * * *`)
- Deletes OddsSnapshot records older than 30 days
- Deletes ApiKeyUsage records older than 90 days
- Logs deletion counts for monitoring and verification
- Includes error handling and graceful failure

### 3. Job Registration
**File**: `dashboard/backend/src/server.ts`
- Import `initializeCleanupJob` from cleanup task
- Call `initializeCleanupJob()` during server startup alongside other scheduled jobs
- Logs status of job initialization

### 4. Documentation
**File**: `dashboard/backend/CHANGELOG.md`
- Documents new retention policies and cleanup jobs

## Performance Impact
- **Positive**: Prevents unbounded database growth, maintains query performance
- **Minimal**: Cleanup job runs once daily at off-peak hours (2 AM UTC), minimal impact on operations
- **Database**: Indices improve cleanup query performance

## Testing Recommendations
1. Verify cleanup job runs daily at 2 AM UTC
2. Monitor deletion counts in logs
3. Test with `deleteMany()` operations on test database
4. Verify older records are purged, newer records retained
5. Check disk space reduction over time

## Migration Notes
- Schema migration required: `prisma migrate dev` will create index
- No data migration needed - cleanup will start automatically
- First cleanup runs at next 2 AM UTC after deployment