### PR TITLE
perf: Optimize statistics queries to use database aggregation (Issue #20)

### DIFF
--- a/dashboard/backend/src/services/bet.service.ts
+++ b/dashboard/backend/src/services/bet.service.ts
@@ -532,7 +532,8 @@ export class BetService {
   }
 
   /**
-   * Get betting statistics
+   * Get betting statistics using database aggregation
+   * Uses groupBy/aggregate instead of loading all rows into memory
    */
   async getStats(filters: StatsFilters = {}): Promise<BetStats> {
     // Build where clause
@@ -568,25 +569,37 @@ export class BetService {
       };
     }
 
-    // Get all bets
-    const bets = await prisma.bet.findMany({
-      where,
-      include: {
-        legs: {
-          include: {
-            game: {
-              include: {
-                sport: true
-              }
-            }
-          }
+    // Run all aggregation queries in parallel
+    const [statusGroups, betTypeStatusGroups, sportBreakdown] = await Promise.all([
+      // 1. Group by status: counts + sums
+      prisma.bet.groupBy({
+        by: ['status'],
+        where,
+        _count: true,
+        _sum: {
+          stake: true,
+          actualPayout: true
         }
-      }
-    });
+      }),
 
-    // Calculate stats
+      // 2. Group by betType + status: counts + sums for byBetType breakdown
+      prisma.bet.groupBy({
+        by: ['betType', 'status'],
+        where,
+        _count: true,
+        _sum: {
+          stake: true,
+          actualPayout: true
+        }
+      }),
+
+      // 3. By sport breakdown using raw SQL (joins through bet_legs → games → sports)
+      this.getStatsBySport(where, filters)
+    ]);
+
+    // Build stats from status groups
     const stats: BetStats = {
-      totalBets: bets.length,
+      totalBets: 0,
       wonBets: 0,
       lostBets: 0,
       pushBets: 0,
@@ -600,43 +613,43 @@ export class BetService {
       bySport: {}
     };
 
-    // Process each bet
-    for (const bet of bets) {
-      const stake = bet.stake.toNumber();
-      const payout = bet.actualPayout?.toNumber() || 0;
+    for (const group of statusGroups) {
+      const count = group._count;
+      const stake = group._sum.stake?.toNumber() || 0;
+      const payout = group._sum.actualPayout?.toNumber() || 0;
 
+      stats.totalBets += count;
       stats.totalStaked += stake;
       stats.totalPayout += payout;
 
-      // Count by status
-      if (bet.status === 'won') stats.wonBets++;
-      else if (bet.status === 'lost') stats.lostBets++;
-      else if (bet.status === 'push') stats.pushBets++;
-      else if (bet.status === 'pending') stats.pendingBets++;
-
-      // By bet type
-      if (!stats.byBetType[bet.betType]) {
-        stats.byBetType[bet.betType] = { count: 0, won: 0, netProfit: 0 };
-      }
-      stats.byBetType[bet.betType]!.count++;
-      if (bet.status === 'won') stats.byBetType[bet.betType]!.won++;
-      stats.byBetType[bet.betType]!.netProfit += (payout - stake);
-
-      // By sport (use first leg's sport)
-      if (bet.legs.length > 0) {
-        const sportKey = bet.legs[0].game.sport.key;
-        if (!stats.bySport[sportKey]) {
-          stats.bySport[sportKey] = { count: 0, won: 0, netProfit: 0 };
-        }
-        stats.bySport[sportKey].count++;
-        if (bet.status === 'won') stats.bySport[sportKey].won++;
-        stats.bySport[sportKey].netProfit += (payout - stake);
+      switch (group.status) {
+        case 'won': stats.wonBets = count; break;
+        case 'lost': stats.lostBets = count; break;
+        case 'push': stats.pushBets = count; break;
+        case 'pending': stats.pendingBets = count; break;
       }
     }
 
+    // Build byBetType from betType+status groups
+    for (const group of betTypeStatusGroups) {
+      const betType = group.betType;
+      const stake = group._sum.stake?.toNumber() || 0;
+      const payout = group._sum.actualPayout?.toNumber() || 0;
+
+      if (!stats.byBetType[betType]) {
+        stats.byBetType[betType] = { count: 0, won: 0, netProfit: 0 };
+      }
+      stats.byBetType[betType]!.count += group._count;
+      if (group.status === 'won') stats.byBetType[betType]!.won += group._count;
+      stats.byBetType[betType]!.netProfit += (payout - stake);
+    }
+
+    // Apply sport breakdown
+    stats.bySport = sportBreakdown;
+
     // Calculate rates
     stats.netProfit = stats.totalPayout - stats.totalStaked;
-    
+
     const settledBets = stats.wonBets + stats.lostBets + stats.pushBets;
     if (settledBets > 0) {
       stats.winRate = (stats.wonBets / settledBets) * 100;
@@ -647,6 +660,78 @@ export class BetService {
     }
 
     return stats;
+  }
+
+  /**
+   * Get stats broken down by sport using a raw SQL query.
+   * Joins bet_legs → games → sports to attribute each bet to its first leg's sport.
+   */
+  private async getStatsBySport(
+    _where: Prisma.BetWhereInput,
+    filters: StatsFilters
+  ): Promise<BetStats['bySport']> {
+    // Build parameterized WHERE conditions for the raw query
+    const conditions: string[] = ['1=1'];
+    const params: (string | Date)[] = [];
+    let paramIndex = 1;
+
+    if (filters.userId) {
+      conditions.push(`b.user_id = $${paramIndex++}`);
+      params.push(filters.userId);
+    }
+    if (filters.betType) {
+      conditions.push(`b.bet_type = $${paramIndex++}`);
+      params.push(filters.betType);
+    }
+    if (filters.startDate) {
+      conditions.push(`b.placed_at >= $${paramIndex++}`);
+      params.push(filters.startDate);
+    }
+    if (filters.endDate) {
+      conditions.push(`b.placed_at <= $${paramIndex++}`);
+      params.push(filters.endDate);
+    }
+    if (filters.sportKey) {
+      conditions.push(`s.key = $${paramIndex++}`);
+      params.push(filters.sportKey);
+    }
+
+    const whereClause = conditions.join(' AND ');
+
+    // Use DISTINCT ON to pick first leg per bet, then aggregate by sport
+    const rows = await prisma.$queryRawUnsafe<Array<{
+      sport_key: string;
+      count: bigint;
+      won: bigint;
+      net_profit: number;
+    }>>(
+      `SELECT
+        s.key AS sport_key,
+        COUNT(*)::bigint AS count,
+        COUNT(*) FILTER (WHERE b.status = 'won')::bigint AS won,
+        COALESCE(SUM(COALESCE(b.actual_payout, 0) - b.stake), 0)::float AS net_profit
+      FROM (
+        SELECT DISTINCT ON (bl.bet_id) bl.bet_id, g.sport_id
+        FROM bet_legs bl
+        JOIN games g ON g.id = bl.game_id
+        ORDER BY bl.bet_id, bl.created_at
+      ) first_leg
+      JOIN bets b ON b.id = first_leg.bet_id
+      JOIN sports s ON s.id = first_leg.sport_id
+      WHERE ${whereClause}
+      GROUP BY s.key`,
+      ...params
+    );
+
+    const bySport: BetStats['bySport'] = {};
+    for (const row of rows) {
+      bySport[row.sport_key] = {
+        count: Number(row.count),
+        won: Number(row.won),
+        netProfit: row.net_profit
+      };
+    }
+    return bySport;
   }
 
   // ========================================================================

--- a/dashboard/backend/tests/bet.service.test.ts
+++ b/dashboard/backend/tests/bet.service.test.ts
@@ -16,6 +16,7 @@ jest.mock('../src/config/database', () => ({
       findUnique: jest.fn(),
       findFirst: jest.fn(),
       findMany: jest.fn(),
+      groupBy: jest.fn(),
       update: jest.fn(),
       count: jest.fn(),
       delete: jest.fn()
@@ -32,6 +33,7 @@ jest.mock('../src/config/database', () => ({
       findUnique: jest.fn(),
       findMany: jest.fn()
     },
+    $queryRawUnsafe: jest.fn(),
     $transaction: jest.fn((callback) => {
       // Mock transaction by calling the callback with mocked prisma
       return callback({
@@ -272,27 +274,33 @@ describe('Bet Service Unit Tests', () => {
 
   describe('Bet Statistics', () => {
     it('should calculate stats from database', async () => {
-      mockPrisma.bet.findMany.mockResolvedValue([
-        {
-          stake: new Decimal(100),
-          actualPayout: new Decimal(190),
-          status: 'won',
-          legs: [{ game: { sport: { key: 'basketball_nba' } } }]
-        },
-        {
-          stake: new Decimal(50),
-          actualPayout: new Decimal(0),
-          status: 'lost',
-          legs: [{ game: { sport: { key: 'basketball_nba' } } }]
-        }
-      ] as any);
+      // Mock groupBy for status aggregation
+      (mockPrisma.bet.groupBy as jest.Mock)
+        .mockResolvedValueOnce([
+          { status: 'won', _count: 1, _sum: { stake: new Decimal(100), actualPayout: new Decimal(190) } },
+          { status: 'lost', _count: 1, _sum: { stake: new Decimal(50), actualPayout: new Decimal(0) } }
+        ])
+        // Mock groupBy for betType+status aggregation
+        .mockResolvedValueOnce([
+          { betType: 'single', status: 'won', _count: 1, _sum: { stake: new Decimal(100), actualPayout: new Decimal(190) } },
+          { betType: 'single', status: 'lost', _count: 1, _sum: { stake: new Decimal(50), actualPayout: new Decimal(0) } }
+        ]);
 
-      mockPrisma.bet.count.mockResolvedValue(2);
+      // Mock raw query for sport breakdown
+      (mockPrisma.$queryRawUnsafe as jest.Mock).mockResolvedValue([
+        { sport_key: 'basketball_nba', count: BigInt(2), won: BigInt(1), net_profit: 40 }
+      ]);
 
       const stats = await service.getStats({});
 
       expect(stats.totalBets).toBe(2);
-      expect(stats).toBeDefined();
+      expect(stats.wonBets).toBe(1);
+      expect(stats.lostBets).toBe(1);
+      expect(stats.totalStaked).toBe(150);
+      expect(stats.totalPayout).toBe(190);
+      expect(stats.netProfit).toBe(40);
+      expect(stats.bySport['basketball_nba']).toEqual({ count: 2, won: 1, netProfit: 40 });
+      expect(stats.byBetType['single']).toEqual({ count: 2, won: 1, netProfit: 40 });
     });
   });
 


### PR DESCRIPTION
## Summary

Replaces the `getStats()` method in `bet.service.ts` that loaded **all bets with legs/games/sports into memory** and computed statistics in JavaScript, with efficient database-level aggregation.

## Problem

`getStats()` used `findMany` with nested includes (`legs → game → sport`), fetching every row into memory before looping to compute counts and sums. For large datasets this causes significant memory usage and slow response times.

## Solution

Three parallel database queries replace the single `findMany` + JS loop:

| Query | Method | Purpose |
|-------|--------|---------|
| Status aggregation | `prisma.bet.groupBy(['status'])` | Counts + sum of stake/payout per status |
| Bet type breakdown | `prisma.bet.groupBy(['betType', 'status'])` | Per-bet-type stats |
| Sport breakdown | Raw SQL with `DISTINCT ON` | Joins `bet_legs → games → sports`, picks first leg per bet |

All three run in **`Promise.all`** for maximum parallelism.

## Changes

- **`bet.service.ts`**: Rewrote `getStats()` + added private `getStatsBySport()` helper
- **`bet.service.test.ts`**: Updated mocks (`groupBy`, `$queryRawUnsafe`) and assertions to match new implementation

Closes #20