### PR TITLE
security: Secure production Docker config — stop exposing PostgreSQL port (Issue #21)

### DIFF
--- a/dashboard/docker-compose.prod.yml
+++ b/dashboard/docker-compose.prod.yml
@@ -45,8 +45,9 @@ services:
     secrets:
       - db_user
       - db_password
-    ports:
-      - "5432:5432"
+    # Internal only - not exposed to host to prevent external DB access
+    expose:
+      - "5432"
     volumes:
       - postgres_data:/var/lib/postgresql/data
     healthcheck:


### PR DESCRIPTION
## Summary

Secures the production Docker configuration by removing the exposed PostgreSQL port.

## Problem

`docker-compose.prod.yml` used `ports: ["5432:5432"]` which makes the database accessible from outside the Docker network — a security risk in production.

## Fix

Changed to `expose: ["5432"]` so PostgreSQL is only reachable by other services within the Docker network (backend, nginx). The dev `docker-compose.yml` intentionally keeps the port exposed for local tooling (Prisma Studio, etc.).

The second item in the issue (API key in query params) is inherent to The Odds API's authentication design and is documented in the operational notes.

Closes #21