### PR TITLE
feat(mcp): Live Tennis API provider — live scores, fixtures, players (#86)

### DIFF
--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -12,6 +12,36 @@
 # Example: ODDS_API_KEY=key_one,key_two
 ODDS_API_KEY=your_odds_api_key_here
 
+# ---------------------------------------------------------------------------
+# Live Tennis API (OPTIONAL) - live tennis scores, fixtures, players
+# ---------------------------------------------------------------------------
+# Set TENNIS_API_KEY to enable the tennis tools (ATP/WTA/Challenger/ITF live
+# scores, fixtures, and player lookups). Leave it unset and the server still
+# runs — the tennis tools simply are not registered.
+#
+# Get a free key (no card) at: https://livetennisapi.com/subscribe/free
+#
+# TIER CONTRACT: free tier for fixtures, player lookups and low-cadence score
+# checks; paid tier for live match-following. The free key is 30 requests/min
+# and 100 requests/DAY. Live scores are included, but the daily cap is the
+# real limit:
+#
+#   * At the default 30s live TTL (CACHE_TTL_TENNIS_LIVE below), following one
+#     three-hour match refreshes ~360 times — it exhausts a free key's whole
+#     day inside a single match.
+#   * A free key sustains ~one score check every 15 minutes (~96/day), plus
+#     fixtures and player lookups, plus develop-and-test.
+#   * For real live match-following use Basic ($9.99/mo, 60/min - 1k/day) or,
+#     for a full Slam board, Pro (300/min - 10k/day).
+#
+# CACHE_TTL_TENNIS_LIVE is the free-tier survival knob. Raising it trades
+# freshness for quota: a 900s TTL keeps a whole day of casual score-checking
+# inside the free 100/day allowance.
+# TENNIS_API_KEY=your_live_tennis_api_key_here
+# CACHE_TTL_TENNIS_LIVE=30       # live match list + single-match score (seconds)
+# CACHE_TTL_TENNIS_FIXTURES=300  # upcoming fixtures
+# CACHE_TTL_TENNIS_PLAYER=3600   # player profile / ranking / Elo
+
 # Optional: Filter Bookmakers/Sportsbooks
 # Comma-separated list of bookmaker keys to include in odds results
 # Leave empty or comment out to include all bookmakers

--- a/mcp/.env.example
+++ b/mcp/.env.example
@@ -41,6 +41,9 @@ ODDS_API_KEY=your_odds_api_key_here
 # CACHE_TTL_TENNIS_LIVE=30       # live match list + single-match score (seconds)
 # CACHE_TTL_TENNIS_FIXTURES=300  # upcoming fixtures
 # CACHE_TTL_TENNIS_PLAYER=3600   # player profile / ranking / Elo
+# CACHE_TTL_TENNIS_USAGE=15      # /usage recovery read — keep short, kept
+#                                # independent of LIVE so a daily-quota re-check
+#                                # is never answered from a raised live cache
 
 # Optional: Filter Bookmakers/Sportsbooks
 # Comma-separated list of bookmaker keys to include in odds results

--- a/mcp/sports_api/tennis_api_handler.py
+++ b/mcp/sports_api/tennis_api_handler.py
@@ -1,0 +1,499 @@
+"""
+Live Tennis API Handler
+=======================
+Handler for the Live Tennis API (https://livetennisapi.com), covering live
+scores, fixtures, and player lookups for ATP, WTA, Challenger and ITF.
+
+Vendor disclosure: this provider is authored by the Live Tennis API team, who
+proposed it in issue #86. Judge it on the merits — it follows the same handler
+pattern as `espn_api_handler.py` and `odds_api_handler.py` and shares the same
+`ResponseCache`.
+
+Tier contract (this is the whole point of the docstring — read it):
+
+    Free tier for fixtures, player lookups and low-cadence score checks;
+    paid tier for live match-following.
+
+The constraint that makes that split real is the free key's daily quota, not
+entitlement. Live scores ARE included on the free tier; the free key is just
+30 requests/minute and **100 requests/day**. At the default 30s live cache TTL
+a single three-hour match refreshes ~360 times — so following one match to the
+end exhausts a free key's whole day inside that one match. A free key sustains
+roughly one score check every 15 minutes (~96/day), plus fixtures and player
+lookups, plus develop-and-test. Following live state for real is Basic
+($9.99/mo, 60/min · 1k/day) or, for a full Slam board, Pro (300/min · 10k/day).
+
+Raising `CACHE_TTL_TENNIS_LIVE` is the free-tier survival knob: a 900s TTL
+keeps a whole day of casual score-checking inside the free 100/day allowance.
+
+v1 scope is deliberately the surface a free key can actually exercise: live
+scores, fixtures, and player lookups. Rank-ordered rankings (Pro) and H2H
+(Basic) are intentionally left out rather than shipped as tools that fail on
+the key our own setup docs tell people to get. Match prices are unaffected and
+stay with the Odds API's `get_odds` and its `tennis_atp_*` passthrough.
+
+Two things this handler does NOT reuse, on purpose:
+
+* `key_manager.py` — it models a monthly, sticky-until-exhausted quota with no
+  per-minute concept, and its marker-string matching would classify a 429
+  burst as a drained key and park it for the process. Tennis is 30/min plus
+  100/day, so this handler carries its own token-bucket minute limiter and
+  tracks the daily quota honestly (from a 429 or from `/usage`), never routing
+  through the manager.
+* the team formatters in `formatter.py` — tennis output is player-shaped and
+  set-by-set, formatted in the tool layer.
+"""
+
+import logging
+import time
+from datetime import datetime, timedelta, timezone
+from typing import Callable, Dict, Optional
+
+import aiohttp
+
+from .cache import ResponseCache, make_key
+
+logger = logging.getLogger(__name__)
+
+# Cache lifetimes by endpoint kind, in seconds. Live scores must stay fresh;
+# fixtures and player profiles change slowly. `live` defaults to 30s to match
+# the ESPN scoreboard, and the composition root lets CACHE_TTL_TENNIS_LIVE
+# override it — that override is the free-tier survival knob (see module doc).
+DEFAULT_TTLS = {
+    "live": 30,       # live match list and single-match score
+    "fixtures": 300,  # upcoming schedule
+    "player": 3600,   # player profile, ranking, Elo
+}
+
+# Free-tier limits, used as defaults for the minute limiter. Basic/Pro raise
+# the per-minute rate; the daily allowance is enforced by the API and observed
+# here rather than assumed.
+FREE_TIER_RPM = 30
+FREE_TIER_RPD = 100
+
+
+def _next_utc_midnight(now: Optional[datetime] = None) -> datetime:
+    """The next 00:00 UTC — when a daily quota resets."""
+    now = now or datetime.now(timezone.utc)
+    tomorrow = (now + timedelta(days=1)).date()
+    return datetime(tomorrow.year, tomorrow.month, tomorrow.day, tzinfo=timezone.utc)
+
+
+class TokenBucket:
+    """A simple per-minute token bucket.
+
+    The free tier is 30 requests/minute. Rather than route a 429 burst through
+    the quota-model key manager (which would misclassify it as an exhausted
+    key and park it), this gates outgoing requests locally: `acquire()` returns
+    False when the minute's budget is spent, and the caller reports a
+    rate-limited result without touching the network or the daily quota.
+
+    `time_func` is injectable so the refill is testable without real sleeping.
+    """
+
+    def __init__(
+        self,
+        rate_per_minute: int = FREE_TIER_RPM,
+        capacity: Optional[int] = None,
+        time_func: Callable[[], float] = time.monotonic,
+    ):
+        self.rate_per_minute = max(1, rate_per_minute)
+        self.rate_per_second = self.rate_per_minute / 60.0
+        self.capacity = float(capacity if capacity is not None else self.rate_per_minute)
+        self._tokens = self.capacity
+        self._time = time_func
+        self._last = self._time()
+
+    def _refill(self) -> None:
+        now = self._time()
+        elapsed = now - self._last
+        if elapsed > 0:
+            self._tokens = min(self.capacity, self._tokens + elapsed * self.rate_per_second)
+            self._last = now
+
+    def acquire(self, tokens: int = 1) -> bool:
+        """Take `tokens` from the bucket. Returns False if not enough remain."""
+        self._refill()
+        if self._tokens >= tokens:
+            self._tokens -= tokens
+            return True
+        return False
+
+    def retry_after(self, tokens: int = 1) -> float:
+        """Seconds until `tokens` would be available, for an honest hint."""
+        self._refill()
+        deficit = tokens - self._tokens
+        if deficit <= 0:
+            return 0.0
+        return round(deficit / self.rate_per_second, 1)
+
+
+class TennisAPIHandler:
+    """Handler for the Live Tennis API (free-tier surface)."""
+
+    BASE_URL = "https://api.livetennisapi.com/api/public/v1"
+
+    def __init__(
+        self,
+        api_key: str,
+        cache: Optional[ResponseCache] = None,
+        ttls: Optional[Dict[str, int]] = None,
+        rate_per_minute: int = FREE_TIER_RPM,
+        rate_limiter: Optional[TokenBucket] = None,
+    ):
+        """Initialize the Live Tennis API handler.
+
+        Args:
+            api_key: A Live Tennis API key (sent as the `X-API-Key` header).
+            cache: Optional shared ResponseCache. One is created if omitted.
+            ttls: Optional per-kind TTL overrides, merged over DEFAULT_TTLS.
+            rate_per_minute: Minute budget for the token bucket (free = 30).
+            rate_limiter: Inject a pre-built TokenBucket (used by tests).
+        """
+        self.api_key = api_key
+        self.session: Optional[aiohttp.ClientSession] = None
+        self.cache = cache if cache is not None else ResponseCache()
+        self.ttls = {**DEFAULT_TTLS, **(ttls or {})}
+        self._bucket = rate_limiter or TokenBucket(rate_per_minute=rate_per_minute)
+
+        # Daily-quota state, learned from a 429 or a `/usage` read. `until` is a
+        # UTC datetime while the key is known-exhausted, else None.
+        self._daily_exhausted_until: Optional[datetime] = None
+        # Last observed usage figures, surfaced by get_quota_status() with no
+        # upstream call (mirrors how the Odds handler reports tracked quota).
+        self._usage: Dict[str, object] = {}
+
+    # -- quota / rate reporting ------------------------------------------------
+
+    @staticmethod
+    def _mask_key(key: str) -> str:
+        """Show only the first and last 4 characters of a key."""
+        if not key:
+            return ""
+        if len(key) <= 8:
+            return "*" * len(key)
+        return f"{key[:4]}...{key[-4:]}"
+
+    def _daily_is_exhausted(self, now: Optional[datetime] = None) -> bool:
+        """True while a known daily-quota exhaustion is still in effect."""
+        if self._daily_exhausted_until is None:
+            return False
+        now = now or datetime.now(timezone.utc)
+        if now >= self._daily_exhausted_until:
+            # The reset time has passed; clear the flag and let requests flow.
+            self._daily_exhausted_until = None
+            return False
+        return True
+
+    def _mark_daily_exhausted(self) -> None:
+        """Park the key until the next UTC midnight after a daily-limit hit."""
+        self._daily_exhausted_until = _next_utc_midnight()
+        logger.warning(
+            "Live Tennis API daily quota exhausted; parking until %s UTC",
+            self._daily_exhausted_until.isoformat(),
+        )
+
+    def get_quota_status(self) -> Dict:
+        """Rate-limit and daily-quota health, with the key masked.
+
+        This makes no upstream call: it reports the token bucket's current
+        state plus the last observed daily usage, so folding it into
+        get_api_status() stays quota-free.
+        """
+        self._bucket._refill()
+        status = {
+            "configured": True,
+            "key": self._mask_key(self.api_key),
+            "per_minute_limit": self._bucket.rate_per_minute,
+            "minute_tokens_available": int(self._bucket._tokens),
+            "daily_exhausted": self._daily_is_exhausted(),
+        }
+        if self._daily_exhausted_until is not None:
+            status["daily_resets_at"] = self._daily_exhausted_until.isoformat()
+        if self._usage:
+            status["usage"] = dict(self._usage)
+        return status
+
+    def _record_usage(self, usage: Dict) -> None:
+        """Fold a `/usage`-shaped block into tracked state.
+
+        Tolerant of key spelling because the field names are the one part of
+        the shape a docstring cannot pin down: accepts remaining/limit/reset
+        under a few common names, ignores what it does not recognise.
+        """
+        if not isinstance(usage, dict):
+            return
+
+        def pick(*names):
+            for n in names:
+                if n in usage and usage[n] is not None:
+                    return usage[n]
+            return None
+
+        remaining = pick("requests_remaining", "remaining", "daily_remaining")
+        limit = pick("daily_limit", "limit", "requests_limit")
+        reset = pick("resets_at", "reset", "reset_at")
+        plan = pick("plan", "tier")
+
+        recorded: Dict[str, object] = {}
+        if remaining is not None:
+            recorded["daily_remaining"] = remaining
+        if limit is not None:
+            recorded["daily_limit"] = limit
+        if reset is not None:
+            recorded["resets_at"] = reset
+        if plan is not None:
+            recorded["plan"] = plan
+        if recorded:
+            self._usage = recorded
+
+        # A reported zero remaining is the same signal as a 429: stop spending.
+        try:
+            if remaining is not None and int(remaining) <= 0:
+                self._mark_daily_exhausted()
+        except (TypeError, ValueError):
+            pass
+
+    # -- HTTP plumbing ---------------------------------------------------------
+
+    async def _get_session(self) -> aiohttp.ClientSession:
+        """Get or create the aiohttp session with the auth header attached."""
+        if self.session is None or self.session.closed:
+            self.session = aiohttp.ClientSession(headers={"X-API-Key": self.api_key})
+        return self.session
+
+    @staticmethod
+    def _is_cacheable(result: Dict) -> bool:
+        """Never cache a failure; a blip would become a full TTL of failure."""
+        return bool(result.get("success"))
+
+    async def _make_request(self, endpoint: str, params: Dict = None, cache_kind: str = "live") -> Dict:
+        """Make a request, serving from cache when possible.
+
+        The API key is deliberately excluded from the cache key: the payload is
+        identical whichever key fetched it, and keying on it would throw the
+        cache away on rotation. Cache hits carry `"cached": True`.
+        """
+        params = dict(params or {})
+        key = make_key("tennis", endpoint, params)
+        ttl = self.ttls.get(cache_kind, 60)
+
+        result, was_hit = await self.cache.get_or_fetch(
+            key,
+            ttl,
+            lambda: self._fetch(endpoint, params),
+            should_cache=self._is_cacheable,
+        )
+
+        if was_hit:
+            result = {**result, "cached": True}
+
+        return result
+
+    async def _fetch(self, endpoint: str, params: Dict) -> Dict:
+        """Perform one live request, gated by the daily quota and minute rate.
+
+        Order matters: a known daily exhaustion short-circuits before the
+        minute limiter, and both short-circuit before the network, so neither a
+        drained day nor a spent minute costs a request or an upstream round
+        trip.
+        """
+        if self._daily_is_exhausted():
+            reset = self._daily_exhausted_until
+            return {
+                "success": False,
+                "error": "Daily request quota exhausted for this Live Tennis API key",
+                "quota": {
+                    "daily_exhausted": True,
+                    "resets_at": reset.isoformat() if reset else None,
+                    "note": (
+                        "Free tier is 100 requests/day. Raise CACHE_TTL_TENNIS_LIVE "
+                        "or use a Basic/Pro key to follow live matches."
+                    ),
+                },
+            }
+
+        if not self._bucket.acquire():
+            return {
+                "success": False,
+                "error": "Per-minute rate limit reached for this Live Tennis API key",
+                "rate_limited": True,
+                "retry_after_seconds": self._bucket.retry_after(),
+            }
+
+        url = f"{self.BASE_URL}{endpoint}"
+        session = await self._get_session()
+
+        try:
+            async with session.get(url, params=params) as response:
+                if response.status == 200:
+                    data = await response.json()
+                    # An envelope may carry a usage block (top-level or under
+                    # `meta`); fold it into tracked quota if present.
+                    if isinstance(data, dict):
+                        usage = data.get("usage")
+                        if usage is None and isinstance(data.get("meta"), dict):
+                            usage = data["meta"].get("usage")
+                        if usage:
+                            self._record_usage(usage)
+                    return {"success": True, "data": data, "cached": False}
+
+                error_text = await response.text()
+
+                if response.status == 429:
+                    # A daily-limit 429 parks the key until reset; a per-minute
+                    # burst is already handled by the bucket above, so treat a
+                    # 429 that slips through as the daily limit.
+                    self._mark_daily_exhausted()
+                    logger.warning("Live Tennis API 429: %s", error_text)
+                    return {
+                        "success": False,
+                        "error": "Live Tennis API rate/quota limit hit (429)",
+                        "details": error_text,
+                        "quota": {
+                            "daily_exhausted": True,
+                            "resets_at": self._daily_exhausted_until.isoformat()
+                            if self._daily_exhausted_until
+                            else None,
+                        },
+                    }
+
+                if response.status in (401, 403):
+                    logger.error("Live Tennis API auth error %s", response.status)
+                    return {
+                        "success": False,
+                        "error": f"Live Tennis API rejected the key (status {response.status})",
+                        "details": error_text,
+                    }
+
+                logger.error("Live Tennis API error %s: %s", response.status, error_text)
+                return {
+                    "success": False,
+                    "error": f"API returned status {response.status}",
+                    "details": error_text,
+                }
+        except Exception as e:  # noqa: BLE001 - report, never crash the tool
+            logger.error("Request failed: %s", str(e))
+            return {"success": False, "error": str(e)}
+
+    # -- endpoints (free-tier surface) ----------------------------------------
+
+    async def get_live_matches(
+        self,
+        tour: Optional[str] = None,
+        status: str = "live",
+        limit: int = 20,
+    ) -> Dict:
+        """List matches and their current score.
+
+        Args:
+            tour: Optional tour filter — atp, wta, challenger, or itf.
+            status: Match status — live (default), upcoming, or completed.
+            limit: Maximum number of matches to return.
+
+        Returns:
+            Dictionary with the matches envelope under `data`.
+        """
+        params: Dict[str, object] = {"status": status, "limit": limit}
+        if tour:
+            params["tour"] = tour.lower()
+        return await self._make_request("/matches", params, cache_kind="live")
+
+    async def get_match_score(self, match_id: str) -> Dict:
+        """Read a single match's live score — the lowest-latency score endpoint.
+
+        Args:
+            match_id: The match id.
+
+        Returns:
+            Dictionary with the score envelope under `data`.
+        """
+        return await self._make_request(f"/matches/{match_id}/score", cache_kind="live")
+
+    async def get_fixtures(
+        self,
+        tour: Optional[str] = None,
+        date: Optional[str] = None,
+        limit: int = 20,
+    ) -> Dict:
+        """Upcoming matches, so callers know what is about to start.
+
+        Args:
+            tour: Optional tour filter — atp, wta, challenger, or itf.
+            date: Optional date filter in YYYY-MM-DD.
+            limit: Maximum number of fixtures to return.
+
+        Returns:
+            Dictionary with the fixtures envelope under `data`.
+        """
+        params: Dict[str, object] = {"limit": limit}
+        if tour:
+            params["tour"] = tour.lower()
+        if date:
+            params["date"] = date
+        return await self._make_request("/fixtures", params, cache_kind="fixtures")
+
+    async def get_player(self, player_id: str) -> Dict:
+        """A player's profile, including current ranking and Elo rating.
+
+        Args:
+            player_id: The player id.
+
+        Returns:
+            Dictionary with the player envelope under `data`.
+        """
+        return await self._make_request(f"/players/{player_id}", cache_kind="player")
+
+    async def get_usage(self) -> Dict:
+        """Read the free-tier `/usage` endpoint and fold it into tracked quota.
+
+        `/usage` is itself free and does not spend the daily allowance, so this
+        can be called to refresh the numbers get_quota_status() reports.
+        """
+        result = await self._make_request("/usage", cache_kind="live")
+        if result.get("success"):
+            data = result.get("data")
+            if isinstance(data, dict):
+                self._record_usage(data.get("data") if isinstance(data.get("data"), dict) else data)
+        return result
+
+    async def close(self):
+        """Close the aiohttp session."""
+        if self.session and not self.session.closed:
+            await self.session.close()
+
+
+# -- domain helper -----------------------------------------------------------
+
+def derive_break_point(score: Dict) -> Optional[bool]:
+    """Derive whether the current point is a break point from a score object.
+
+    Applies the documented rule: it is a break point when the receiver holds
+    advantage, or the receiver has 40 while the server has 0/15/30. It never
+    holds inside a tiebreak, and is undefined (None) when the server or the
+    per-player points are unknown.
+
+    `score` is the Live Tennis API score object: `server` is 1, 2 or null, and
+    `points` is a two-element list [player1_point, player2_point] using the
+    tennis point labels ("0", "15", "30", "40", "AD").
+    """
+    if not isinstance(score, dict):
+        return None
+    if score.get("tiebreak") or score.get("is_tiebreak"):
+        return None
+
+    server = score.get("server")
+    points = score.get("points")
+    if server not in (1, 2) or not isinstance(points, (list, tuple)) or len(points) < 2:
+        return None
+
+    server_idx = server - 1
+    receiver_idx = 1 - server_idx
+    server_pt = str(points[server_idx])
+    receiver_pt = str(points[receiver_idx])
+
+    if receiver_pt == "AD":
+        return True
+    if receiver_pt == "40" and server_pt in ("0", "15", "30"):
+        return True
+    return False

--- a/mcp/sports_api/tennis_api_handler.py
+++ b/mcp/sports_api/tennis_api_handler.py
@@ -63,7 +63,14 @@ DEFAULT_TTLS = {
     "live": 30,       # live match list and single-match score
     "fixtures": 300,  # upcoming schedule
     "player": 3600,   # player profile, ranking, Elo
+    "usage": 15,      # /usage recovery read — kept short on purpose (see below)
 }
+
+# /usage is the documented recovery call: it is free, it does not spend the
+# daily allowance, and it is the only way to check a locally-guessed daily park
+# against the API's own count. It gets its OWN short TTL rather than sharing
+# `live` (which the composition root may raise to 900s as the survival knob), so
+# a recovery check is never answered from a 15-minute-old cache.
 
 # Free-tier limits, used as defaults for the minute limiter. Basic/Pro raise
 # the per-minute rate; the daily allowance is enforced by the API and observed
@@ -77,6 +84,135 @@ def _next_utc_midnight(now: Optional[datetime] = None) -> datetime:
     now = now or datetime.now(timezone.utc)
     tomorrow = (now + timedelta(days=1)).date()
     return datetime(tomorrow.year, tomorrow.month, tomorrow.day, tzinfo=timezone.utc)
+
+
+# A 429 can mean either the per-minute OR the per-day window was exceeded. The
+# process-local token bucket starts full, so a restart mid-minute — or a second
+# client sharing the key — sends a request the bucket thinks is within budget
+# but the API rejects as a MINUTE burst. Parking the daily quota on that wastes
+# ~90 of the day's 100 requests until UTC midnight. So a 429 is classified
+# before it is allowed to park the day: only a genuine daily 429 parks, and
+# everything ambiguous is treated as a minute-scale back-off (a wrong minute
+# back-off costs ~2 seconds; a wrong daily park costs the rest of the day).
+_MINUTE_SCALE_MAX_SECONDS = 120
+
+
+def _to_int(value) -> Optional[int]:
+    """Best-effort int parse; returns None on anything non-numeric."""
+    if value is None:
+        return None
+    try:
+        return int(str(value).strip())
+    except (TypeError, ValueError):
+        return None
+
+
+def _parse_retry_after(value: Optional[str], now: Optional[datetime] = None) -> Optional[float]:
+    """Parse a Retry-After header to seconds-from-now.
+
+    Handles both documented forms: delta-seconds ("120") and an HTTP-date
+    ("Wed, 21 Oct 2026 07:28:00 GMT"). Returns None when absent or unparseable.
+    """
+    if value is None:
+        return None
+    text = str(value).strip()
+    if not text:
+        return None
+    try:
+        return max(0.0, float(text))
+    except (TypeError, ValueError):
+        pass
+    try:
+        from email.utils import parsedate_to_datetime
+
+        when = parsedate_to_datetime(text)
+    except (TypeError, ValueError):
+        return None
+    if when is None:
+        return None
+    if when.tzinfo is None:
+        when = when.replace(tzinfo=timezone.utc)
+    now = now or datetime.now(timezone.utc)
+    return max(0.0, (when - now).total_seconds())
+
+
+def _classify_rate_limit(headers, body_text: str, now: Optional[datetime] = None) -> Dict[str, object]:
+    """Classify a 429 as ``minute``-scale or ``daily``-scale.
+
+    Signals are consulted strongest-first: an explicit rate-limit scope/window
+    header, then per-window ``remaining`` headers, then the response body
+    wording, then the magnitude of Retry-After. When nothing positively says
+    "daily", the answer is ``minute`` — the safe default, because only a
+    genuine daily 429 should park the key until reset.
+
+    Args:
+        headers: The response headers (aiohttp CIMultiDict or a plain dict).
+        body_text: The 429 response body.
+        now: Injectable clock for Retry-After date math (testing).
+
+    Returns:
+        ``{"scale", "retry_after_seconds", "signal"}``.
+    """
+    # Normalise to a case-insensitive lookup that works for both aiohttp's
+    # CIMultiDict and a plain dict passed by a unit test.
+    lowered: Dict[str, object] = {}
+    if headers:
+        try:
+            items = list(headers.items())
+        except AttributeError:
+            items = []
+        for k, v in items:
+            lowered[str(k).lower()] = v
+
+    def h(*names):
+        for n in names:
+            v = lowered.get(n.lower())
+            if v is not None:
+                return v
+        return None
+
+    retry_after = _parse_retry_after(h("Retry-After"), now=now)
+    body = (body_text or "").lower()
+
+    def result(scale: str, signal: str) -> Dict[str, object]:
+        return {"scale": scale, "retry_after_seconds": retry_after, "signal": signal}
+
+    # 1. Explicit scope/window header, e.g. "X-RateLimit-Scope: minute".
+    scope = h("X-RateLimit-Scope", "RateLimit-Scope", "X-RateLimit-Window", "RateLimit-Window")
+    if scope is not None:
+        s = str(scope).lower()
+        if any(w in s for w in ("day", "daily", "date")):
+            return result("daily", f"scope={scope}")
+        if any(w in s for w in ("min", "sec", "burst")):
+            return result("minute", f"scope={scope}")
+
+    # 2. Per-window remaining headers. A day window at 0 is daily; a minute
+    #    window at 0 while the day still has room is minute-scale.
+    day_remaining = _to_int(
+        h("X-RateLimit-Remaining-Day", "X-RateLimit-Daily-Remaining", "X-RateLimit-Remaining-Daily")
+    )
+    min_remaining = _to_int(
+        h("X-RateLimit-Remaining-Minute", "X-RateLimit-Remaining-Min")
+    )
+    if day_remaining is not None and day_remaining <= 0:
+        return result("daily", "day-remaining<=0")
+    if min_remaining is not None and min_remaining <= 0 and (day_remaining is None or day_remaining > 0):
+        return result("minute", "minute-remaining<=0")
+
+    # 3. Body wording. Check the daily vocabulary first so "daily rate limit"
+    #    is read as daily rather than tripping the generic minute markers.
+    if any(w in body for w in ("per day", "daily", "day limit", "quota exceeded", "requests/day")):
+        return result("daily", "body=daily")
+    if any(w in body for w in ("per minute", "per-minute", "minute", "per second", "rate limit", "too many", "slow down")):
+        return result("minute", "body=minute")
+
+    # 4. Retry-After magnitude: a back-off longer than a minute window is
+    #    day-scale; a short one is a minute burst.
+    if retry_after is not None and retry_after > _MINUTE_SCALE_MAX_SECONDS:
+        return result("daily", "retry-after-large")
+
+    # 5. Default: minute-scale (see module note above).
+    return result("minute", "default-minute")
 
 
 class TokenBucket:
@@ -126,6 +262,21 @@ class TokenBucket:
         if deficit <= 0:
             return 0.0
         return round(deficit / self.rate_per_second, 1)
+
+    def penalize(self, seconds: float = 0.0) -> None:
+        """Empty the bucket, optionally holding it empty for `seconds`.
+
+        Called when the API reports a minute-scale 429 the local bucket did not
+        predict — a restart reset it to full, or a second client shares the key.
+        Draining aligns the local view with reality so we stop hammering for the
+        rest of the window instead of re-issuing on the next full-bucket tick.
+        `seconds` (e.g. a Retry-After hint) pushes the bucket negative so the
+        next token is not available until roughly that long from now.
+        """
+        self._refill()
+        self._tokens = 0.0
+        if seconds and seconds > 0:
+            self._tokens = -max(0.0, float(seconds)) * self.rate_per_second
 
 
 class TennisAPIHandler:
@@ -247,10 +398,21 @@ class TennisAPIHandler:
         if recorded:
             self._usage = recorded
 
-        # A reported zero remaining is the same signal as a 429: stop spending.
+        # The reported remaining count is authoritative in BOTH directions:
+        #   * <= 0 is the same signal as a daily 429 — park the key.
+        #   * > 0 means the key is usable right now, so clear any park. This is
+        #     what makes /usage a real recovery call: if a 429 was misclassified
+        #     as daily exhaustion, the API's own count releases the key.
         try:
-            if remaining is not None and int(remaining) <= 0:
-                self._mark_daily_exhausted()
+            if remaining is not None:
+                if int(remaining) <= 0:
+                    self._mark_daily_exhausted()
+                elif self._daily_exhausted_until is not None:
+                    logger.info(
+                        "Live Tennis API reports %s requests remaining; clearing daily park",
+                        remaining,
+                    )
+                    self._daily_exhausted_until = None
         except (TypeError, ValueError):
             pass
 
@@ -267,12 +429,21 @@ class TennisAPIHandler:
         """Never cache a failure; a blip would become a full TTL of failure."""
         return bool(result.get("success"))
 
-    async def _make_request(self, endpoint: str, params: Dict = None, cache_kind: str = "live") -> Dict:
+    async def _make_request(
+        self,
+        endpoint: str,
+        params: Dict = None,
+        cache_kind: str = "live",
+        bypass_daily_gate: bool = False,
+    ) -> Dict:
         """Make a request, serving from cache when possible.
 
         The API key is deliberately excluded from the cache key: the payload is
         identical whichever key fetched it, and keying on it would throw the
         cache away on rotation. Cache hits carry `"cached": True`.
+
+        `bypass_daily_gate` lets the free `/usage` recovery read reach the API
+        even while the key is locally parked (see get_usage / _fetch).
         """
         params = dict(params or {})
         key = make_key("tennis", endpoint, params)
@@ -281,7 +452,7 @@ class TennisAPIHandler:
         result, was_hit = await self.cache.get_or_fetch(
             key,
             ttl,
-            lambda: self._fetch(endpoint, params),
+            lambda: self._fetch(endpoint, params, bypass_daily_gate=bypass_daily_gate),
             should_cache=self._is_cacheable,
         )
 
@@ -290,15 +461,20 @@ class TennisAPIHandler:
 
         return result
 
-    async def _fetch(self, endpoint: str, params: Dict) -> Dict:
+    async def _fetch(self, endpoint: str, params: Dict, bypass_daily_gate: bool = False) -> Dict:
         """Perform one live request, gated by the daily quota and minute rate.
 
         Order matters: a known daily exhaustion short-circuits before the
         minute limiter, and both short-circuit before the network, so neither a
         drained day nor a spent minute costs a request or an upstream round
         trip.
+
+        `bypass_daily_gate=True` skips only the daily short-circuit — the free
+        `/usage` read must reach the API even while parked, because it is the
+        only way to check the local park against the real count. The minute
+        limiter still applies: it is a live request.
         """
-        if self._daily_is_exhausted():
+        if not bypass_daily_gate and self._daily_is_exhausted():
             reset = self._daily_exhausted_until
             return {
                 "success": False,
@@ -341,21 +517,45 @@ class TennisAPIHandler:
                 error_text = await response.text()
 
                 if response.status == 429:
-                    # A daily-limit 429 parks the key until reset; a per-minute
-                    # burst is already handled by the bucket above, so treat a
-                    # 429 that slips through as the daily limit.
-                    self._mark_daily_exhausted()
-                    logger.warning("Live Tennis API 429: %s", error_text)
+                    # The local minute bucket starts full, so a 429 here does
+                    # NOT prove the day is drained — a restart or a second
+                    # client on the same key produces a MINUTE-scale 429 the
+                    # bucket never saw. Classify before parking: only a genuine
+                    # daily 429 calls _mark_daily_exhausted(); a minute burst is
+                    # a minute back-off that leaves the daily quota untouched.
+                    classification = _classify_rate_limit(response.headers, error_text)
+                    logger.warning(
+                        "Live Tennis API 429 (%s): %s",
+                        classification["signal"],
+                        error_text,
+                    )
+                    if classification["scale"] == "daily":
+                        self._mark_daily_exhausted()
+                        return {
+                            "success": False,
+                            "error": "Live Tennis API daily quota limit hit (429)",
+                            "details": error_text,
+                            "quota": {
+                                "daily_exhausted": True,
+                                "resets_at": self._daily_exhausted_until.isoformat()
+                                if self._daily_exhausted_until
+                                else None,
+                            },
+                        }
+
+                    # Minute-scale: align the local bucket with the API's view
+                    # so we stop hammering, but leave the daily quota alone.
+                    retry_after = classification["retry_after_seconds"]
+                    self._bucket.penalize(retry_after or 0.0)
+                    hint = self._bucket.retry_after()
+                    if retry_after is not None:
+                        hint = max(hint, round(float(retry_after), 1))
                     return {
                         "success": False,
-                        "error": "Live Tennis API rate/quota limit hit (429)",
+                        "error": "Live Tennis API per-minute rate limit hit (429)",
                         "details": error_text,
-                        "quota": {
-                            "daily_exhausted": True,
-                            "resets_at": self._daily_exhausted_until.isoformat()
-                            if self._daily_exhausted_until
-                            else None,
-                        },
+                        "rate_limited": True,
+                        "retry_after_seconds": hint,
                     }
 
                 if response.status in (401, 403):
@@ -448,9 +648,15 @@ class TennisAPIHandler:
         """Read the free-tier `/usage` endpoint and fold it into tracked quota.
 
         `/usage` is itself free and does not spend the daily allowance, so this
-        can be called to refresh the numbers get_quota_status() reports.
+        can be called to refresh the numbers get_quota_status() reports — and,
+        critically, to recover from a wrong daily park. It therefore bypasses
+        the daily short-circuit (otherwise the one call that could correct a bad
+        park would be blocked by that very park) and is cached under its own
+        short `usage` TTL so recovery is never answered from a stale `live`
+        cache. A positive remaining in the response clears the park, via
+        _record_usage.
         """
-        result = await self._make_request("/usage", cache_kind="live")
+        result = await self._make_request("/usage", cache_kind="usage", bypass_daily_gate=True)
         if result.get("success"):
             data = result.get("data")
             if isinstance(data, dict):

--- a/mcp/sports_api/tools/__init__.py
+++ b/mcp/sports_api/tools/__init__.py
@@ -2,6 +2,7 @@
 
 from .odds_tools import register_odds_tools
 from .espn_tools import register_espn_tools
+from .tennis_tools import register_tennis_tools
 from .format_tools import register_format_tools
 from .artifact_tools import register_artifact_tools
 from .diagnostics_tools import register_diagnostics_tools
@@ -9,6 +10,7 @@ from .diagnostics_tools import register_diagnostics_tools
 __all__ = [
     "register_odds_tools",
     "register_espn_tools",
+    "register_tennis_tools",
     "register_format_tools",
     "register_artifact_tools",
     "register_diagnostics_tools",

--- a/mcp/sports_api/tools/diagnostics_tools.py
+++ b/mcp/sports_api/tools/diagnostics_tools.py
@@ -4,8 +4,9 @@ Diagnostics MCP Tools
 Introspection tools for API quota, key health, and cache stats. Neither
 tool makes an upstream call, so both cost no quota.
 
-`register_diagnostics_tools(mcp, response_cache, odds_handler, dashboard_tool_names)`
-attaches every tool in this module to the given FastMCP instance.
+`register_diagnostics_tools(mcp, response_cache, odds_handler,
+dashboard_tool_names, tennis_handler=None)` attaches every tool in this module
+to the given FastMCP instance.
 """
 
 import logging
@@ -19,6 +20,7 @@ def register_diagnostics_tools(
     response_cache,
     odds_handler,
     dashboard_tool_names: List[str],
+    tennis_handler=None,
 ) -> None:
     """Attach the diagnostics tools to `mcp`.
 
@@ -29,6 +31,10 @@ def register_diagnostics_tools(
             not configured
         dashboard_tool_names: Names of the dashboard tools registered
             (empty when DASHBOARD_API_KEY is not configured)
+        tennis_handler: A TennisAPIHandler instance, or None if TENNIS_API_KEY
+            is not configured. When present, its per-minute and daily-quota
+            state is folded into get_api_status from tracked state (no upstream
+            call, so get_api_status stays quota-free).
     """
 
     @mcp.tool()
@@ -49,6 +55,10 @@ def register_diagnostics_tools(
                   invalid    — rejected as a bad key; retired for this session
               cache: hit rate, entry count, and upstream requests avoided
               dashboard: whether the BetTrack dashboard tools are registered
+              tennis_api: when TENNIS_API_KEY is set, the Live Tennis API key's
+                  per-minute budget and last observed daily quota (masked key,
+                  daily_exhausted flag, reset time). Reported from tracked
+                  state, so it too costs no quota.
 
         Example:
             get_api_status() -> {"odds_api": {...}, "cache": {...}}
@@ -70,6 +80,19 @@ def register_diagnostics_tools(
             }
 
         status["espn_api"] = {"configured": True, "requires_key": False}
+
+        if tennis_handler:
+            # Reported from tracked state (token bucket + last observed daily
+            # usage / a prior 429), so this costs no quota. `/usage` itself is
+            # free-tier; call get_tennis_* activity or the handler's get_usage
+            # to refresh the daily figures.
+            status["tennis_api"] = tennis_handler.get_quota_status()
+        else:
+            status["tennis_api"] = {
+                "configured": False,
+                "note": "TENNIS_API_KEY is not set. Tennis tools are not registered.",
+            }
+
         return status
 
     @mcp.tool()

--- a/mcp/sports_api/tools/tennis_tools.py
+++ b/mcp/sports_api/tools/tennis_tools.py
@@ -1,0 +1,243 @@
+"""
+Live Tennis API MCP Tools
+=========================
+Live scores, fixtures, and player lookups backed by `TennisAPIHandler`.
+
+Unlike the always-on ESPN tools, these are gated on `TENNIS_API_KEY`:
+`register_tennis_tools(mcp, tennis_handler)` registers nothing at all when
+`tennis_handler` is None, so a user who never sets a tennis key is not shown
+tools that could only fail for them.
+
+Tool names are prefixed (`get_tennis_*`) — the server's tool namespace is flat
+and already deep.
+
+Tier note (see the handler module docstring for the arithmetic): live scores
+are free-tier by entitlement but bound by the free key's 100 requests/day, so
+following a match to the end needs a Basic/Pro key or a raised
+CACHE_TTL_TENNIS_LIVE. Fixtures and player lookups sit comfortably in the free
+tier. Rank-ordered rankings and H2H are intentionally not in v1.
+"""
+
+from typing import Optional
+
+from ..tennis_api_handler import derive_break_point
+
+
+# Tour labels are cheap to normalise in one place.
+_VALID_TOURS = {"atp", "wta", "challenger", "itf"}
+
+
+def _summarize_match(match: dict) -> dict:
+    """Reduce a raw match object to the essentials, deriving break-point state.
+
+    Keeps the response small (the ESPN tools do the same) and adds a derived
+    `break_point` flag from the documented rule when the server and points are
+    known, so a client does not have to reconstruct it.
+    """
+    players = match.get("players", {}) or {}
+    p1 = players.get("p1", {}) or {}
+    p2 = players.get("p2", {}) or {}
+    score = match.get("score", {}) or {}
+
+    summary = {
+        "id": match.get("id"),
+        "tour": match.get("tour"),
+        "status": match.get("status"),
+        "players": {
+            "p1": {"id": p1.get("id"), "name": p1.get("name")},
+            "p2": {"id": p2.get("id"), "name": p2.get("name")},
+        },
+        "score": {
+            "sets": score.get("sets"),
+            "games": score.get("games"),
+            "points": score.get("points"),
+            "server": score.get("server"),
+        },
+    }
+
+    tournament = match.get("tournament")
+    if tournament:
+        summary["tournament"] = {
+            "name": tournament.get("name"),
+            "surface": tournament.get("surface"),
+            "round": tournament.get("round"),
+        }
+
+    # Prefer an explicit flag from the API; otherwise derive it.
+    if "break_point" in score:
+        summary["score"]["break_point"] = score.get("break_point")
+    else:
+        derived = derive_break_point(score)
+        if derived is not None:
+            summary["score"]["break_point"] = derived
+
+    return summary
+
+
+def register_tennis_tools(mcp, tennis_handler) -> None:
+    """Attach the Live Tennis API tools to `mcp`, if a handler was built.
+
+    Args:
+        mcp: A FastMCP server instance.
+        tennis_handler: A TennisAPIHandler instance, or None when
+            TENNIS_API_KEY is not configured — in which case nothing is
+            registered.
+    """
+    if tennis_handler is None:
+        return
+
+    @mcp.tool()
+    async def get_tennis_scoreboard(
+        tour: Optional[str] = None,
+        status: str = "live",
+        limit: int = 20,
+    ) -> dict:
+        """
+        Get tennis matches and their current score (ATP, WTA, Challenger, ITF).
+
+        Quota note: live scores are free-tier but the free key is 100
+        requests/day. At the default 30s cache TTL, following a single match to
+        the end exhausts a free key within that match. For low-cadence checks,
+        fixtures and players this is comfortably free; for live match-following
+        use a Basic/Pro key or raise CACHE_TTL_TENNIS_LIVE.
+
+        Args:
+            tour: Optional tour filter — atp, wta, challenger, or itf.
+            status: Match status — live (default), upcoming, or completed.
+            limit: Maximum number of matches to return (default: 20, max: 50).
+
+        Returns:
+            Dictionary with a streamlined `matches` list. Each match carries
+            players, the set/games/points score object, the server (1|2|null),
+            and a `break_point` flag (from the API, else derived).
+
+        Example:
+            get_tennis_scoreboard() -> live matches across all tours
+            get_tennis_scoreboard(tour="atp") -> live ATP matches
+        """
+        if tour and tour.lower() not in _VALID_TOURS:
+            return {
+                "success": False,
+                "error": f"Unknown tour '{tour}'. Use one of: {', '.join(sorted(_VALID_TOURS))}.",
+            }
+
+        limit = max(1, min(limit, 50))
+        result = await tennis_handler.get_live_matches(tour=tour, status=status, limit=limit)
+        if not result.get("success"):
+            return result
+
+        payload = result.get("data", {})
+        matches = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if not isinstance(matches, list):
+            matches = []
+
+        summarized = [_summarize_match(m) for m in matches[:limit]]
+        return {
+            "success": True,
+            "matches": summarized,
+            "count": len(summarized),
+            "status": status,
+            "cached": result.get("cached", False),
+        }
+
+    @mcp.tool()
+    async def get_tennis_match_score(match_id: str) -> dict:
+        """
+        Get one tennis match's current score — the lowest-latency score read.
+
+        Args:
+            match_id: The match id (from get_tennis_scoreboard or get_tennis_fixtures).
+
+        Returns:
+            Dictionary with the match's score object (sets, games, points,
+            server) and a derived `break_point` flag when server and points
+            are known.
+
+        Example:
+            get_tennis_match_score("m_8f2c1a") -> current score for that match
+        """
+        result = await tennis_handler.get_match_score(match_id)
+        if not result.get("success"):
+            return result
+
+        payload = result.get("data", {})
+        match = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if not isinstance(match, dict):
+            return {"success": True, "match": match, "cached": result.get("cached", False)}
+
+        return {
+            "success": True,
+            "match": _summarize_match(match),
+            "cached": result.get("cached", False),
+        }
+
+    @mcp.tool()
+    async def get_tennis_fixtures(
+        tour: Optional[str] = None,
+        date: Optional[str] = None,
+        limit: int = 20,
+    ) -> dict:
+        """
+        Get upcoming tennis fixtures (free tier).
+
+        Args:
+            tour: Optional tour filter — atp, wta, challenger, or itf.
+            date: Optional date filter in YYYY-MM-DD.
+            limit: Maximum number of fixtures to return (default: 20, max: 50).
+
+        Returns:
+            Dictionary with an `fixtures` list of upcoming matches (players,
+            tournament, scheduled start when provided).
+
+        Example:
+            get_tennis_fixtures(tour="wta") -> upcoming WTA fixtures
+            get_tennis_fixtures(date="2026-05-31") -> fixtures on that date
+        """
+        if tour and tour.lower() not in _VALID_TOURS:
+            return {
+                "success": False,
+                "error": f"Unknown tour '{tour}'. Use one of: {', '.join(sorted(_VALID_TOURS))}.",
+            }
+
+        limit = max(1, min(limit, 50))
+        result = await tennis_handler.get_fixtures(tour=tour, date=date, limit=limit)
+        if not result.get("success"):
+            return result
+
+        payload = result.get("data", {})
+        fixtures = payload.get("data", payload) if isinstance(payload, dict) else payload
+        if not isinstance(fixtures, list):
+            fixtures = []
+
+        return {
+            "success": True,
+            "fixtures": fixtures[:limit],
+            "count": len(fixtures[:limit]),
+            "cached": result.get("cached", False),
+        }
+
+    @mcp.tool()
+    async def get_tennis_player(player_id: str) -> dict:
+        """
+        Get a tennis player's profile, including current ranking and Elo (free tier).
+
+        Args:
+            player_id: The player id (from a match's players, or a fixture).
+
+        Returns:
+            Dictionary with the player's profile under `player`.
+
+        Example:
+            get_tennis_player("p_alcaraz") -> profile, ranking, Elo rating
+        """
+        result = await tennis_handler.get_player(player_id)
+        if not result.get("success"):
+            return result
+
+        payload = result.get("data", {})
+        player = payload.get("data", payload) if isinstance(payload, dict) else payload
+        return {
+            "success": True,
+            "player": player,
+            "cached": result.get("cached", False),
+        }

--- a/mcp/sports_mcp_server.py
+++ b/mcp/sports_mcp_server.py
@@ -9,9 +9,10 @@ Model Context Protocol server providing access to sports data from:
 Supports natural language queries for sports information.
 
 Tool definitions live in sports_api/tools/, grouped by the API they call
-(odds_tools, espn_tools, format_tools, artifact_tools, diagnostics_tools).
-This file is the composition root: it loads configuration, builds the
-shared handlers and cache, and registers each tool group against them.
+(odds_tools, espn_tools, tennis_tools, format_tools, artifact_tools,
+diagnostics_tools). This file is the composition root: it loads configuration,
+builds the shared handlers and cache, and registers each tool group against
+them.
 """
 
 import os
@@ -23,10 +24,12 @@ from mcp.server import FastMCP
 # Import API handlers
 from sports_api.odds_api_handler import OddsAPIHandler
 from sports_api.espn_api_handler import ESPNAPIHandler
+from sports_api.tennis_api_handler import TennisAPIHandler
 from sports_api.cache import ResponseCache
 from sports_api.tools import (
     register_odds_tools,
     register_espn_tools,
+    register_tennis_tools,
     register_format_tools,
     register_artifact_tools,
     register_diagnostics_tools,
@@ -93,7 +96,7 @@ if odds_api_key_str:
         odds_api_keys = keys[0]  # Single key as string
     else:
         odds_api_keys = keys  # Multiple keys, drained one at a time
-        logger.info(f"🎲 Easter egg activated! {len(keys)} API keys loaded")
+        logger.info(f"\U0001F3B2 Easter egg activated! {len(keys)} API keys loaded")
 
 # Load bookmaker configuration
 bookmakers_filter_str = os.getenv("BOOKMAKERS_FILTER", "").strip()
@@ -151,6 +154,14 @@ espn_ttls = {
     "scoreboard": _env_int("CACHE_TTL_SCOREBOARD", 30),
     "summary": _env_int("CACHE_TTL_SCOREBOARD", 30),
 }
+# Tennis live TTL is the free-tier survival knob: at 30s, following one match
+# is ~360 requests against a free key's 100/day; a larger value keeps a day of
+# casual score-checking inside the free allowance. See .env.example.
+tennis_ttls = {
+    "live": _env_int("CACHE_TTL_TENNIS_LIVE", 30),
+    "fixtures": _env_int("CACHE_TTL_TENNIS_FIXTURES", 300),
+    "player": _env_int("CACHE_TTL_TENNIS_PLAYER", 3600),
+}
 
 if cache_enabled:
     logger.info(
@@ -168,6 +179,24 @@ odds_handler = OddsAPIHandler(
     ttls=odds_ttls,
 ) if odds_api_keys else None
 espn_handler = ESPNAPIHandler(cache=response_cache, ttls=espn_ttls)
+
+# Live Tennis API handler, gated on TENNIS_API_KEY. Without a key we build no
+# handler and register no tools, so a user who only wants US team sports never
+# sees tennis tools that could only fail for them. The handler carries its own
+# per-minute token bucket and daily-quota tracking rather than routing through
+# the Odds key manager, which models a different quota shape.
+tennis_api_key = os.getenv("TENNIS_API_KEY", "").strip()
+if not tennis_api_key:
+    logger.info(
+        "TENNIS_API_KEY not set. Tennis tools are unavailable; other sports "
+        "tools work normally. Get a free key at "
+        "https://livetennisapi.com/subscribe/free to enable them."
+    )
+tennis_handler = (
+    TennisAPIHandler(api_key=tennis_api_key, cache=response_cache, ttls=tennis_ttls)
+    if tennis_api_key
+    else None
+)
 
 
 # ============================================================================
@@ -211,9 +240,12 @@ except ImportError as exc:
 
 register_odds_tools(mcp, odds_handler)
 register_espn_tools(mcp, espn_handler)
+register_tennis_tools(mcp, tennis_handler)
 register_format_tools(mcp, espn_handler, odds_handler)
 register_artifact_tools(mcp, odds_handler)
-register_diagnostics_tools(mcp, response_cache, odds_handler, dashboard_tool_names)
+register_diagnostics_tools(
+    mcp, response_cache, odds_handler, dashboard_tool_names, tennis_handler
+)
 
 
 # ============================================================================
@@ -224,6 +256,7 @@ if __name__ == "__main__":
     logger.info("Starting Sports Data MCP Server...")
     logger.info(f"Odds API configured: {odds_handler is not None}")
     logger.info(f"ESPN API configured: True")
+    logger.info(f"Tennis API configured: {tennis_handler is not None}")
     logger.info(f"Dashboard configured: {len(dashboard_tool_names) > 0}")
     logger.info(f"Response cache: {'enabled' if cache_enabled else 'disabled'}")
     if odds_handler and len(odds_handler.api_keys) > 1:

--- a/mcp/sports_mcp_server.py
+++ b/mcp/sports_mcp_server.py
@@ -161,6 +161,10 @@ tennis_ttls = {
     "live": _env_int("CACHE_TTL_TENNIS_LIVE", 30),
     "fixtures": _env_int("CACHE_TTL_TENNIS_FIXTURES", 300),
     "player": _env_int("CACHE_TTL_TENNIS_PLAYER", 3600),
+    # /usage is the free recovery read; keep it short so a park re-check is
+    # never served from a raised (up to 900s) live cache. Independent of
+    # CACHE_TTL_TENNIS_LIVE on purpose.
+    "usage": _env_int("CACHE_TTL_TENNIS_USAGE", 15),
 }
 
 if cache_enabled:

--- a/mcp/tests/test_tennis_api_handler.py
+++ b/mcp/tests/test_tennis_api_handler.py
@@ -1,0 +1,325 @@
+"""
+Tests for sports_api/tennis_api_handler.py
+
+Mocks the underlying aiohttp session with aioresponses so no real Live Tennis
+API requests are made. The response samples are real Live Tennis API shapes:
+the {"data": ...} envelope, players.p1/p2, and the set/games/points/server
+score object.
+
+The two pieces of logic a reviewer cannot check by eye are covered explicitly:
+the per-minute token bucket, and the daily-quota-exhausted short-circuit.
+"""
+
+import re
+from datetime import datetime, timezone
+
+import pytest
+from aioresponses import aioresponses
+
+from sports_api.cache import ResponseCache
+from sports_api.tennis_api_handler import (
+    TennisAPIHandler,
+    TokenBucket,
+    derive_break_point,
+    _next_utc_midnight,
+)
+
+TENNIS_URL_RE = re.compile(r"^https://api\.livetennisapi\.com/.*")
+
+# A real-shape live match envelope: the API returns {"data": [...]} and each
+# match carries players.p1/p2 and a score object of sets/games/points/server.
+LIVE_MATCHES_ENVELOPE = {
+    "data": [
+        {
+            "id": "m_8f2c1a",
+            "tour": "atp",
+            "status": "live",
+            "tournament": {"name": "Roland Garros", "surface": "clay", "round": "QF"},
+            "players": {
+                "p1": {"id": "p_alcaraz", "name": "Carlos Alcaraz", "country": "ESP"},
+                "p2": {"id": "p_sinner", "name": "Jannik Sinner", "country": "ITA"},
+            },
+            "score": {
+                "sets": [1, 1],
+                "games": [[6, 4], [3, 6], [2, 1]],
+                "points": ["30", "40"],
+                "server": 1,
+            },
+        }
+    ]
+}
+
+
+@pytest.fixture
+def handler():
+    # A disabled cache forces every call through _fetch, which is what the
+    # rate-limit and quota tests need to observe.
+    return TennisAPIHandler(api_key="twjp_test_key", cache=ResponseCache(enabled=False))
+
+
+class TestGetLiveMatches:
+    @pytest.mark.asyncio
+    async def test_success(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=LIVE_MATCHES_ENVELOPE, status=200)
+            result = await handler.get_live_matches(tour="atp")
+
+        assert result["success"] is True
+        assert result["data"]["data"][0]["id"] == "m_8f2c1a"
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_non_200_returns_failure(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, status=500, body="server error")
+            result = await handler.get_live_matches()
+
+        assert result["success"] is False
+        assert "500" in result["error"]
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_result_is_cached_on_second_call(self):
+        handler = TennisAPIHandler(api_key="twjp_test_key")  # cache enabled
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=LIVE_MATCHES_ENVELOPE, status=200)
+            first = await handler.get_live_matches(tour="atp")
+            second = await handler.get_live_matches(tour="atp")
+
+        assert first.get("cached") is False
+        assert second.get("cached") is True
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_auth_error_reports_rejected_key(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, status=401, body="unauthenticated")
+            result = await handler.get_live_matches()
+
+        assert result["success"] is False
+        assert "rejected the key" in result["error"]
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_request_exception_returns_failure(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, exception=ConnectionError("network down"))
+            result = await handler.get_live_matches()
+
+        assert result["success"] is False
+        assert "network down" in result["error"]
+        await handler.close()
+
+
+class TestOtherEndpoints:
+    @pytest.mark.asyncio
+    async def test_get_match_score(self, handler):
+        score_envelope = {"data": {"id": "m_8f2c1a", "score": {"server": 2, "points": ["0", "0"]}}}
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=score_envelope, status=200)
+            result = await handler.get_match_score("m_8f2c1a")
+
+        assert result["success"] is True
+        assert result["data"]["data"]["id"] == "m_8f2c1a"
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_get_fixtures(self, handler):
+        fixtures_envelope = {
+            "data": [
+                {
+                    "id": "m_upcoming1",
+                    "tour": "wta",
+                    "status": "upcoming",
+                    "players": {"p1": {"name": "A"}, "p2": {"name": "B"}},
+                    "start_time": "2026-05-31T09:00:00Z",
+                }
+            ]
+        }
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=fixtures_envelope, status=200)
+            result = await handler.get_fixtures(tour="wta", date="2026-05-31")
+
+        assert result["success"] is True
+        assert result["data"]["data"][0]["status"] == "upcoming"
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_get_player(self, handler):
+        player_envelope = {
+            "data": {
+                "id": "p_alcaraz",
+                "name": "Carlos Alcaraz",
+                "country": "ESP",
+                "ranking": 2,
+                "elo": 2185,
+            }
+        }
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=player_envelope, status=200)
+            result = await handler.get_player("p_alcaraz")
+
+        assert result["success"] is True
+        assert result["data"]["data"]["ranking"] == 2
+        await handler.close()
+
+
+class TestTokenBucket:
+    def test_starts_full_and_drains(self):
+        bucket = TokenBucket(rate_per_minute=3, time_func=lambda: 1000.0)
+        assert bucket.acquire() is True
+        assert bucket.acquire() is True
+        assert bucket.acquire() is True
+        # Clock frozen, so no refill: the fourth request is denied.
+        assert bucket.acquire() is False
+
+    def test_refills_over_time(self):
+        now = {"t": 1000.0}
+        bucket = TokenBucket(rate_per_minute=60, capacity=1, time_func=lambda: now["t"])
+        assert bucket.acquire() is True
+        assert bucket.acquire() is False
+        # 60/min == 1/sec, so one second restores exactly one token.
+        now["t"] += 1.0
+        assert bucket.acquire() is True
+
+    def test_retry_after_is_positive_when_empty(self):
+        bucket = TokenBucket(rate_per_minute=60, capacity=1, time_func=lambda: 1000.0)
+        assert bucket.acquire() is True
+        assert bucket.retry_after() > 0
+
+
+class TestRateLimiting:
+    @pytest.mark.asyncio
+    async def test_minute_limit_short_circuits_without_upstream(self):
+        # One token, frozen clock: the first request spends it, the second is
+        # denied locally. Only one upstream response is registered, so a second
+        # upstream call would raise — proving the limiter never made it.
+        bucket = TokenBucket(rate_per_minute=1, capacity=1, time_func=lambda: 5000.0)
+        handler = TennisAPIHandler(
+            api_key="twjp_test_key",
+            cache=ResponseCache(enabled=False),
+            rate_limiter=bucket,
+        )
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=LIVE_MATCHES_ENVELOPE, status=200)
+            first = await handler.get_live_matches()
+            second = await handler.get_live_matches()
+
+        assert first["success"] is True
+        assert second["success"] is False
+        assert second["rate_limited"] is True
+        assert second["retry_after_seconds"] > 0
+        await handler.close()
+
+
+class TestDailyQuota:
+    @pytest.mark.asyncio
+    async def test_429_parks_key_until_reset_and_next_call_short_circuits(self, handler):
+        # First call gets a 429 (daily limit). Only one 429 is registered, so
+        # if the second call reached the network aioresponses would raise —
+        # the daily-exhausted short-circuit is what keeps it local.
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, status=429, body="daily limit exceeded")
+            first = await handler.get_live_matches()
+            second = await handler.get_live_matches()
+
+        assert first["success"] is False
+        assert first["quota"]["daily_exhausted"] is True
+        assert second["success"] is False
+        assert "Daily request quota exhausted" in second["error"]
+        assert handler._daily_exhausted_until is not None
+        assert handler._daily_exhausted_until > datetime.now(timezone.utc)
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_quota_clears_after_reset(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, status=429, body="daily limit exceeded")
+            await handler.get_live_matches()
+
+        # Rewind the reset into the past; the next check should clear it.
+        handler._daily_exhausted_until = datetime(2000, 1, 1, tzinfo=timezone.utc)
+        assert handler._daily_is_exhausted() is False
+        assert handler._daily_exhausted_until is None
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_usage_endpoint_populates_quota_status(self, handler):
+        usage_envelope = {
+            "data": {
+                "plan": "free",
+                "requests_remaining": 37,
+                "daily_limit": 100,
+                "resets_at": "2026-05-31T00:00:00Z",
+            }
+        }
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=usage_envelope, status=200)
+            await handler.get_usage()
+
+        status = handler.get_quota_status()
+        assert status["configured"] is True
+        assert status["key"] == "twjp..._key"  # masked first4...last4
+        assert status["usage"]["daily_remaining"] == 37
+        assert status["usage"]["daily_limit"] == 100
+        assert status["daily_exhausted"] is False
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_usage_zero_remaining_marks_exhausted(self, handler):
+        usage_envelope = {"data": {"requests_remaining": 0, "daily_limit": 100}}
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=usage_envelope, status=200)
+            await handler.get_usage()
+
+        assert handler._daily_is_exhausted() is True
+        await handler.close()
+
+
+class TestQuotaStatus:
+    def test_reports_masked_key_and_no_upstream(self):
+        handler = TennisAPIHandler(api_key="twjp_abcdefgh")
+        status = handler.get_quota_status()
+        assert status["configured"] is True
+        assert status["key"] != "twjp_abcdefgh"
+        assert status["key"].startswith("twjp")
+        assert status["per_minute_limit"] == 30
+        assert status["daily_exhausted"] is False
+
+
+class TestNextUtcMidnight:
+    def test_is_after_now_and_at_midnight(self):
+        base = datetime(2026, 5, 31, 14, 30, tzinfo=timezone.utc)
+        nxt = _next_utc_midnight(base)
+        assert nxt == datetime(2026, 6, 1, 0, 0, tzinfo=timezone.utc)
+        assert nxt > base
+
+
+class TestDeriveBreakPoint:
+    def test_receiver_advantage_is_break_point(self):
+        # server=1, so receiver is p2 (index 1) holding AD.
+        score = {"server": 1, "points": ["40", "AD"]}
+        assert derive_break_point(score) is True
+
+    def test_receiver_40_vs_server_30_is_break_point(self):
+        score = {"server": 1, "points": ["30", "40"]}
+        assert derive_break_point(score) is True
+
+    def test_server_ahead_is_not_break_point(self):
+        score = {"server": 1, "points": ["40", "30"]}
+        assert derive_break_point(score) is False
+
+    def test_deuce_is_not_break_point(self):
+        score = {"server": 1, "points": ["40", "40"]}
+        assert derive_break_point(score) is False
+
+    def test_tiebreak_is_undefined(self):
+        score = {"server": 1, "points": ["6", "5"], "tiebreak": True}
+        assert derive_break_point(score) is None
+
+    def test_null_server_is_undefined(self):
+        score = {"server": None, "points": ["40", "30"]}
+        assert derive_break_point(score) is None
+
+    def test_missing_points_is_undefined(self):
+        assert derive_break_point({"server": 1}) is None

--- a/mcp/tests/test_tennis_api_handler.py
+++ b/mcp/tests/test_tennis_api_handler.py
@@ -22,6 +22,8 @@ from sports_api.tennis_api_handler import (
     TokenBucket,
     derive_break_point,
     _next_utc_midnight,
+    _classify_rate_limit,
+    _parse_retry_after,
 )
 
 TENNIS_URL_RE = re.compile(r"^https://api\.livetennisapi\.com/.*")
@@ -274,6 +276,201 @@ class TestDailyQuota:
 
         assert handler._daily_is_exhausted() is True
         await handler.close()
+
+
+class TestClassifyRateLimit:
+    """FIX 1 — a 429 is minute-scale unless something says otherwise."""
+
+    def test_ambiguous_429_defaults_to_minute(self):
+        # No headers, generic body: must NOT be read as daily exhaustion.
+        c = _classify_rate_limit({}, "429 Too Many Requests")
+        assert c["scale"] == "minute"
+
+    def test_empty_body_and_headers_defaults_to_minute(self):
+        c = _classify_rate_limit(None, "")
+        assert c["scale"] == "minute"
+        assert c["signal"] == "default-minute"
+
+    def test_daily_body_wording_is_daily(self):
+        assert _classify_rate_limit({}, "Daily limit exceeded")["scale"] == "daily"
+        assert _classify_rate_limit({}, "quota exceeded for today")["scale"] == "daily"
+        assert _classify_rate_limit({}, "100 requests/day cap reached")["scale"] == "daily"
+
+    def test_minute_body_wording_is_minute(self):
+        assert _classify_rate_limit({}, "Per-minute rate limit exceeded")["scale"] == "minute"
+        assert _classify_rate_limit({}, "Slow down")["scale"] == "minute"
+
+    def test_scope_header_minute_beats_daily_body_noise(self):
+        # An explicit scope header is the strongest signal.
+        c = _classify_rate_limit({"X-RateLimit-Scope": "minute"}, "daily-ish text")
+        assert c["scale"] == "minute"
+
+    def test_scope_header_daily(self):
+        assert _classify_rate_limit({"RateLimit-Scope": "day"}, "")["scale"] == "daily"
+
+    def test_day_remaining_zero_is_daily(self):
+        c = _classify_rate_limit({"X-RateLimit-Remaining-Day": "0"}, "")
+        assert c["scale"] == "daily"
+
+    def test_minute_remaining_zero_with_day_left_is_minute(self):
+        c = _classify_rate_limit(
+            {"X-RateLimit-Remaining-Minute": "0", "X-RateLimit-Remaining-Day": "58"}, ""
+        )
+        assert c["scale"] == "minute"
+
+    def test_headers_are_case_insensitive(self):
+        c = _classify_rate_limit({"x-ratelimit-remaining-day": "0"}, "")
+        assert c["scale"] == "daily"
+
+    def test_large_retry_after_is_daily(self):
+        c = _classify_rate_limit({"Retry-After": "3600"}, "")
+        assert c["scale"] == "daily"
+        assert c["retry_after_seconds"] == 3600.0
+
+    def test_short_retry_after_is_minute(self):
+        c = _classify_rate_limit({"Retry-After": "12"}, "")
+        assert c["scale"] == "minute"
+        assert c["retry_after_seconds"] == 12.0
+
+
+class TestParseRetryAfter:
+    def test_delta_seconds(self):
+        assert _parse_retry_after("30") == 30.0
+
+    def test_absent(self):
+        assert _parse_retry_after(None) is None
+        assert _parse_retry_after("") is None
+
+    def test_http_date(self):
+        now = datetime(2026, 5, 31, 12, 0, 0, tzinfo=timezone.utc)
+        secs = _parse_retry_after("Sun, 31 May 2026 12:01:00 GMT", now=now)
+        assert secs == 60.0
+
+
+class TestMinuteScale429DoesNotPark:
+    """FIX 1 — a minute-scale 429 must NOT park the daily quota."""
+
+    @pytest.mark.asyncio
+    async def test_minute_429_reports_rate_limited_and_leaves_daily_unparked(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(
+                TENNIS_URL_RE,
+                status=429,
+                headers={"X-RateLimit-Scope": "minute", "Retry-After": "20"},
+                body="per-minute rate limit",
+            )
+            result = await handler.get_live_matches()
+
+        assert result["success"] is False
+        assert result["rate_limited"] is True
+        assert result["retry_after_seconds"] >= 20
+        # The daily quota must remain untouched: no park, no daily short-circuit.
+        assert handler._daily_exhausted_until is None
+        assert handler._daily_is_exhausted() is False
+        assert "quota" not in result
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_minute_429_drains_bucket_so_next_call_is_local(self, handler):
+        # After a minute-scale 429 the local bucket is drained, so the very next
+        # call is denied locally without a second upstream request. Only one 429
+        # is registered; a second network hit would raise.
+        with aioresponses() as mocked:
+            mocked.get(
+                TENNIS_URL_RE,
+                status=429,
+                headers={"X-RateLimit-Scope": "minute"},
+                body="per-minute rate limit",
+            )
+            first = await handler.get_live_matches()
+            second = await handler.get_live_matches()
+
+        assert first["rate_limited"] is True
+        assert second["rate_limited"] is True
+        assert second["retry_after_seconds"] > 0
+        # Still not a daily park.
+        assert handler._daily_exhausted_until is None
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_daily_429_still_parks(self, handler):
+        with aioresponses() as mocked:
+            mocked.get(
+                TENNIS_URL_RE,
+                status=429,
+                headers={"X-RateLimit-Remaining-Day": "0"},
+                body="daily quota exceeded",
+            )
+            result = await handler.get_live_matches()
+
+        assert result["success"] is False
+        assert result["quota"]["daily_exhausted"] is True
+        assert handler._daily_exhausted_until is not None
+        await handler.close()
+
+
+class TestTokenBucketPenalize:
+    def test_penalize_drains_to_empty(self):
+        bucket = TokenBucket(rate_per_minute=60, capacity=10, time_func=lambda: 1000.0)
+        assert bucket.acquire() is True
+        bucket.penalize()
+        assert bucket.acquire() is False
+
+    def test_penalize_with_seconds_holds_empty_longer(self):
+        now = {"t": 1000.0}
+        bucket = TokenBucket(rate_per_minute=60, capacity=10, time_func=lambda: now["t"])
+        # 60/min == 1 token/sec. Penalize for 5s -> ~5s until the first token.
+        bucket.penalize(5.0)
+        assert bucket.retry_after() >= 5.0
+        now["t"] += 6.0
+        assert bucket.acquire() is True
+
+
+class TestUsageRecovery:
+    """FIX 2 — /usage bypasses the daily gate, clears the park, is short-TTL."""
+
+    def test_usage_ttl_is_short_and_independent_of_live(self):
+        # Even when the live TTL is raised to the 900s survival knob, /usage
+        # keeps its own short TTL so a recovery read is never stale.
+        handler = TennisAPIHandler(api_key="twjp_test_key", ttls={"live": 900})
+        assert handler.ttls["live"] == 900
+        assert handler.ttls["usage"] == 15
+        assert handler.ttls["usage"] < handler.ttls["live"]
+
+    @pytest.mark.asyncio
+    async def test_usage_reaches_api_while_daily_parked(self, handler):
+        # Park the key as if a 429 exhausted the day...
+        handler._mark_daily_exhausted()
+        assert handler._daily_is_exhausted() is True
+
+        # ...a normal call short-circuits locally (no upstream needed)...
+        parked = await handler.get_live_matches()
+        assert "Daily request quota exhausted" in parked["error"]
+
+        # ...but /usage still reaches the API and reports real headroom, which
+        # clears the park. Only the /usage response is registered; if the daily
+        # gate had blocked it, no network call would occur and remaining would
+        # never be read.
+        usage_envelope = {"data": {"requests_remaining": 63, "daily_limit": 100}}
+        with aioresponses() as mocked:
+            mocked.get(TENNIS_URL_RE, payload=usage_envelope, status=200)
+            result = await handler.get_usage()
+
+        assert result["success"] is True
+        assert handler._daily_is_exhausted() is False
+        assert handler._daily_exhausted_until is None
+        await handler.close()
+
+    @pytest.mark.asyncio
+    async def test_positive_remaining_clears_park(self, handler):
+        handler._mark_daily_exhausted()
+        handler._record_usage({"requests_remaining": 42, "daily_limit": 100})
+        assert handler._daily_is_exhausted() is False
+
+    @pytest.mark.asyncio
+    async def test_zero_remaining_still_parks(self, handler):
+        handler._record_usage({"requests_remaining": 0, "daily_limit": 100})
+        assert handler._daily_is_exhausted() is True
 
 
 class TestQuotaStatus:

--- a/mcp/tests/test_tools_registration.py
+++ b/mcp/tests/test_tools_registration.py
@@ -21,6 +21,7 @@ import pytest
 from sports_api.tools import (
     register_odds_tools,
     register_espn_tools,
+    register_tennis_tools,
     register_format_tools,
     register_artifact_tools,
     register_diagnostics_tools,
@@ -144,6 +145,84 @@ class TestRegisterEspnTools:
         assert result == {"success": False, "error": "boom"}
 
 
+class TestRegisterTennisTools:
+    def test_no_key_registers_nothing(self):
+        # Gated on TENNIS_API_KEY: with no handler, nothing is registered, so a
+        # user without a tennis key is never shown tools that can only fail.
+        mcp = FakeMCP()
+        register_tennis_tools(mcp, tennis_handler=None)
+        assert mcp.tools == {}
+
+    def test_registers_expected_tools_with_handler(self):
+        mcp = FakeMCP()
+        register_tennis_tools(mcp, tennis_handler=MagicMock())
+        assert set(mcp.tools) == {
+            "get_tennis_scoreboard",
+            "get_tennis_match_score",
+            "get_tennis_fixtures",
+            "get_tennis_player",
+        }
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_summarizes_and_derives_break_point(self):
+        handler = MagicMock()
+        handler.get_live_matches = AsyncMock(return_value={
+            "success": True,
+            "cached": False,
+            "data": {
+                "data": [
+                    {
+                        "id": "m_1",
+                        "tour": "atp",
+                        "status": "live",
+                        "players": {
+                            "p1": {"id": "p_a", "name": "Player A"},
+                            "p2": {"id": "p_b", "name": "Player B"},
+                        },
+                        "score": {
+                            "sets": [1, 0],
+                            "games": [[6, 4], [3, 2]],
+                            "points": ["30", "40"],  # receiver (p2) 40 vs server 30
+                            "server": 1,
+                        },
+                    }
+                ]
+            },
+        })
+        mcp = FakeMCP()
+        register_tennis_tools(mcp, tennis_handler=handler)
+
+        result = await mcp.tools["get_tennis_scoreboard"](tour="atp")
+
+        handler.get_live_matches.assert_awaited_once_with(tour="atp", status="live", limit=20)
+        assert result["success"] is True
+        assert result["count"] == 1
+        match = result["matches"][0]
+        assert match["players"]["p1"]["name"] == "Player A"
+        assert match["score"]["server"] == 1
+        # Derived from the documented rule: receiver at 40 vs server at 30.
+        assert match["score"]["break_point"] is True
+
+    @pytest.mark.asyncio
+    async def test_scoreboard_rejects_unknown_tour(self):
+        mcp = FakeMCP()
+        register_tennis_tools(mcp, tennis_handler=MagicMock())
+
+        result = await mcp.tools["get_tennis_scoreboard"](tour="cricket")
+        assert result["success"] is False
+        assert "cricket" in result["error"]
+
+    @pytest.mark.asyncio
+    async def test_failure_passthrough(self):
+        handler = MagicMock()
+        handler.get_player = AsyncMock(return_value={"success": False, "error": "boom"})
+        mcp = FakeMCP()
+        register_tennis_tools(mcp, tennis_handler=handler)
+
+        result = await mcp.tools["get_tennis_player"]("p_x")
+        assert result == {"success": False, "error": "boom"}
+
+
 class TestRegisterFormatTools:
     def test_registers_expected_tools(self):
         mcp = FakeMCP()
@@ -245,6 +324,32 @@ class TestRegisterDiagnosticsTools:
         status = mcp.tools["get_api_status"]()
         assert status["odds_api"]["configured"] is False
         assert status["dashboard"]["tools_registered"] == 1
+        # No tennis handler passed -> reported as not configured.
+        assert status["tennis_api"]["configured"] is False
+
+    def test_get_api_status_folds_in_tennis_quota(self):
+        cache = MagicMock()
+        cache.stats.return_value = {"hits": 0}
+        tennis = MagicMock()
+        tennis.get_quota_status.return_value = {
+            "configured": True,
+            "key": "twjp...key",
+            "daily_exhausted": False,
+        }
+        mcp = FakeMCP()
+        register_diagnostics_tools(
+            mcp,
+            response_cache=cache,
+            odds_handler=None,
+            dashboard_tool_names=[],
+            tennis_handler=tennis,
+        )
+
+        status = mcp.tools["get_api_status"]()
+        # Folded from tracked state, so it costs no upstream call.
+        tennis.get_quota_status.assert_called_once_with()
+        assert status["tennis_api"]["configured"] is True
+        assert status["tennis_api"]["daily_exhausted"] is False
 
     def test_clear_cache(self):
         cache = MagicMock()


### PR DESCRIPTION
Closes #86.

## Disclosure
Vendor-authored: I run the Live Tennis API, so this provider is a vendor contribution — judge it on the merits. It follows your `espn_api_handler.py` pattern, shares your `ResponseCache`, and touches exactly one file outside its own module (`diagnostics_tools.py`, for the quota line you asked for).

## Scope (as agreed in the thread)
**v1 = live + fixtures + players only** — the surface a free key can genuinely exercise. Rankings (Pro) and H2H (Basic) are left out rather than shipped as tools that 402 on the key your setup docs tell people to get. Match prices are unaffected and stay with `get_odds` and its `tennis_atp_*` passthrough.

The tier contract is in the module docstring and `.env.example` with the arithmetic, not just the adjectives: *free tier for fixtures, player lookups and low-cadence score checks; paid tier for live match-following.* At the default 30s live TTL, following one three-hour match is ~360 requests against a free key's 100/day — it exhausts the day inside one match. `CACHE_TTL_TENNIS_LIVE` is the survival knob (a 900s TTL keeps a whole casual Slam day inside the free allowance).

## The 7 points
1. **`sports_api/tennis_api_handler.py`** — handler + a per-minute token bucket. It does **not** route through `key_manager.py`: that models a monthly sticky-until-exhausted quota with no per-minute concept, and its marker matching would classify a 429 burst as a drained key and park it. Instead the bucket gates outgoing requests locally, and the daily quota is tracked honestly (a 429 parks the key until the next UTC midnight; `/usage` refreshes the numbers). No team formatters reused — tennis output is player-shaped and set-by-set.
2. **`sports_api/tools/tennis_tools.py`** exporting `register_tennis_tools(mcp, handler)`, re-exported from `tools/__init__.py`. Tool names prefixed: `get_tennis_scoreboard`, `get_tennis_match_score`, `get_tennis_fixtures`, `get_tennis_player`.
3. **Gated on `TENNIS_API_KEY`.** No key → no handler → nothing registered (`register_tennis_tools` returns early when the handler is None). Verified by a test.
4. **Shared `ResponseCache`** via constructor, `"tennis"` namespace in `make_key`, `_is_cacheable` copied from ESPN (failures never cache), API key kept out of the cache key. The composition root merges `CACHE_TTL_TENNIS_LIVE` (default 30) / `_FIXTURES` / `_PLAYER` over the handler defaults.
5. **`.env.example`** documents the TTL knob and tier arithmetic right next to `TENNIS_API_KEY`.
6. **Quota reporting folded into `get_api_status`** in `diagnostics_tools.py` — from the handler's tracked state, so it stays quota-free (no `/usage` call inside the diagnostics tool). It's the only file outside my own that I touched.
7. **Tests**: `tests/test_tennis_api_handler.py` with `aioresponses`, mirroring `test_espn_api_handler.py`, plus a no-key case in `test_tools_registration.py`. The rate limiter and the daily-quota-exhausted branch are covered specifically. Response samples are real Live Tennis API shapes (the `{"data": ...}` envelope, `players.p1/p2`, the `sets/games/points/server` score object), not invented.

## Verification
Full suite: **174 passed** (was 143 before). Coverage on `sports_api/`: handler 95%, TOTAL 65% (target 50%). Run with `cd mcp && pip install -r requirements-dev.txt && pytest tests/`.

One note: I matched the existing hand-formatted style of `odds_api_handler.py`/`espn_tools.py` (which aren't Black-clean in the tree today) rather than Black-format only the new files and diverge from their neighbors — happy to run Black across the module if you'd prefer.

If a vendor-contributed provider still isn't a direction you want, close it — no hard feelings, and thanks for the detailed scoping in the thread.