### PR TITLE
fix(release): package the MCPB properly so releases actually publish

### DIFF
--- a/.github/workflows/on-demand-release.yml
+++ b/.github/workflows/on-demand-release.yml
@@ -211,26 +211,13 @@ jobs:
         working-directory: ./dashboard
         run: npm run build:frontend
 
+      # scripts/build-mcpb.mjs owns the payload. The inline list this replaced
+      # omitted dashboard_api/, which sports_mcp_server.py imports at load time,
+      # so bundles built here were missing a package the server needs.
       - name: Build MCPB package
         id: mcpb
         if: '!inputs.dry_run && contains(steps.release.outputs.artifacts, ''mcpb'')'
-        run: |
-          MCP_VERSION="${{ steps.release.outputs.version_mcp }}"
-          BUILD_DIR="mcp/build/sports-data-mcp"
-          mkdir -p "$BUILD_DIR" mcp/releases
-
-          for f in sports_mcp_server.py dashboard_mcp_server.py manifest.json \
-                    requirements.txt mcpb_bootstrap.py setup.py .env.example \
-                    INSTALL_INSTRUCTIONS.md; do
-            [[ -f "mcp/$f" ]] && cp "mcp/$f" "$BUILD_DIR/"
-          done
-
-          cp -r mcp/sports_api "$BUILD_DIR/"
-          find "$BUILD_DIR" -type d -name __pycache__ -exec rm -rf {} + 2>/dev/null || true
-
-          MCPB_PATH="mcp/releases/sports-data-mcp-v${MCP_VERSION}.mcpb"
-          (cd "$BUILD_DIR" && zip -r "../../../${MCPB_PATH}" . -x "*.pyc")
-          echo "path=${MCPB_PATH}" >> "$GITHUB_OUTPUT"
+        run: node scripts/build-mcpb.mjs
 
       - name: Create distribution ZIPs
         id: zips

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -225,10 +225,14 @@ jobs:
       # -----------------------------------------------------------------------
       # Build
       # -----------------------------------------------------------------------
-      - name: Build MCP Server
+      # Was `python -m mcpb build`, but `mcpb` is in neither requirements.txt nor
+      # requirements-dev.txt, so this step failed and took the whole job — and
+      # therefore the GitHub Release — down with it. scripts/build-mcpb.mjs owns
+      # the payload and needs no Python packaging tooling.
+      - name: Build MCPB package
+        id: mcpb
         if: contains(needs.plan.outputs.artifacts, 'mcpb')
-        working-directory: ./mcp
-        run: python -m mcpb build
+        run: node scripts/build-mcpb.mjs
 
       - name: Build backend
         if: contains(needs.plan.outputs.artifacts, 'npm-backend')
@@ -340,13 +344,6 @@ jobs:
       # -----------------------------------------------------------------------
       # GitHub Release
       # -----------------------------------------------------------------------
-      - name: Find MCPB package
-        id: mcpb
-        if: contains(needs.plan.outputs.artifacts, 'mcpb')
-        run: |
-          MCPB_FILE=$(ls mcp/releases/*.mcpb 2>/dev/null | head -n 1 || true)
-          echo "path=$MCPB_FILE" >> "$GITHUB_OUTPUT"
-
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -297,6 +297,11 @@ jobs:
       - name: Validate docker build plan
         run: node scripts/docker-build.mjs all --dry-run
 
+      # Builds the real bundle and validates it. This is the check that would
+      # have caught the release job dying on `python -m mcpb build`.
+      - name: Build and validate the MCPB package
+        run: node scripts/build-mcpb.mjs
+
   build-validation:
     name: Build Validation
     runs-on: ubuntu-latest

--- a/.gitleaks.toml
+++ b/.gitleaks.toml
@@ -17,6 +17,10 @@ tags = ["key", "odds-api"]
 description = "Templates, docs, and fixtures that carry placeholder values only"
 
 paths = [
+  # scripts/bump-version.mjs stores a SHA-256 per tracked file here. A file of
+  # 64-char hex digests reads as high-entropy secrets to the default ruleset, so
+  # every version bump commit would fail the scan. It contains only digests.
+  '''(^|/)\.bump-hashes\.json$''',
   '''\.env\.example$''',
   '''\.env\.production\.example$''',
   '''\.env\.prod\.example$''',

--- a/dashboard/package.json
+++ b/dashboard/package.json
@@ -33,7 +33,10 @@
     "docker:build": "node ../scripts/docker-build.mjs",
     "docker:dry": "npm run docker:build -- all --dry-run",
     "docker:push": "npm run docker:build -- all --push",
-    "test:docker": "node --test ../scripts/docker-build.test.mjs"
+    "test:docker": "node --test ../scripts/docker-build.test.mjs",
+    "mcpb": "node ../scripts/build-mcpb.mjs",
+    "mcpb:dry": "npm run mcpb -- --dry-run",
+    "test:mcpb": "node --test ../scripts/build-mcpb.test.mjs"
   },
   "devDependencies": {
     "concurrently": "^8.2.2",

--- a/scripts/BUMP-QUICK-START.md
+++ b/scripts/BUMP-QUICK-START.md
@@ -143,5 +143,5 @@ Restrict it to specific packages the same way: `npm run bump:tag -- mcp`.
 
 ```bash
 npm run test:bump      # bump script only
-npm run test:scripts   # bump + release
+npm run test:scripts   # every script suite
 ```

--- a/scripts/BUMP-SYSTEM.md
+++ b/scripts/BUMP-SYSTEM.md
@@ -201,7 +201,7 @@ a separate namespace and do not trigger that workflow.
 
 ```bash
 npm run test:bump              # from dashboard/
-npm run test:scripts           # bump + release together
+npm run test:scripts           # every script suite
 node --test scripts/*.test.mjs
 ```
 

--- a/scripts/DOCKER-SYSTEM.md
+++ b/scripts/DOCKER-SYSTEM.md
@@ -162,7 +162,7 @@ in sync by hand. The PowerShell shim translates `-Backend` style switches to
 
 ```bash
 npm run test:docker      # docker script only
-npm run test:scripts     # bump + release + docker
+npm run test:scripts     # every script suite (213 tests)
 ```
 
 There are no end-to-end tests — building an image needs a daemon and minutes per

--- a/scripts/RELEASE-SYSTEM.md
+++ b/scripts/RELEASE-SYSTEM.md
@@ -128,6 +128,50 @@ describe repo-wide work, so `npm run release -- mcp` records itself in the root
 changelog but leaves the pending project notes in place for the next full
 release.
 
+## The MCPB Bundle
+
+The MCP server ships as an `.mcpb` — a zip of its runtime payload that Claude
+Desktop installs. [build-mcpb.mjs](./build-mcpb.mjs) is the only thing that
+knows what goes in it, and `release.mjs` calls it after the bump, so the bundle
+always carries the version that was just written into `manifest.json`.
+
+```bash
+npm run mcpb              # package the current version
+npm run mcpb:dry          # list the payload, write nothing
+```
+
+Output: `mcp/releases/sports-data-mcp-v<version>.mcpb` (gitignored).
+
+### What it replaced
+
+Three implementations had drifted apart:
+
+- `release.yml` ran `python -m mcpb build`, but `mcpb` is in neither
+  `requirements.txt` nor `requirements-dev.txt`. The step failed, and because it
+  ran before `Create GitHub Release`, **the whole release job died and no
+  Release was ever created** — the tag appeared and nothing else did.
+- `on-demand-release.yml` zipped an inline file list that omitted
+  `dashboard_api/`, which `sports_mcp_server.py` imports at module load. Bundles
+  built that way were missing a package the server needs to start.
+- `build.sh` had the correct list and was the only one that was right. It now
+  delegates like everything else.
+
+Every bundle shipped so far also declared `"icon": "icon.png"` in its manifest
+without including the file. The payload now carries it.
+
+### Validation
+
+A bundle is checked before it is written, and all problems are reported at once:
+
+- `manifest.json`'s version matches `package.json` — a desync means something
+  wrote one without the other, and Claude Desktop reports the manifest's
+- the declared `server.entry_point` is in the payload
+- every asset the manifest references (the icon) is in the payload
+- required files and both Python packages are present
+- the finished archive is read back and must have `manifest.json` at its root
+
+`__pycache__/` and `*.pyc` never ship.
+
 ## Workflows
 
 Two entry points, one script:
@@ -217,7 +261,8 @@ npm run release -- --push
 
 ```bash
 npm run test:release            # release script only
-npm run test:scripts            # release + bump, 127 tests
+npm run test:mcpb               # MCPB packaging only
+npm run test:scripts            # every script suite, 213 tests
 ```
 
 Unit tests cover scope and argument parsing, tag resolution and its inverse,

--- a/scripts/build-mcpb.mjs
+++ b/scripts/build-mcpb.mjs
@@ -1,0 +1,518 @@
+#!/usr/bin/env node
+
+/**
+ * BetTrack MCPB packaging.
+ *
+ *   npm run mcpb                       package the current mcp/ version
+ *   npm run mcpb -- --dry-run          list what would go in, write nothing
+ *   npm run mcpb -- --json             machine-readable result (for CI)
+ *
+ * An .mcpb is a zip of the MCP server's runtime payload, installed by Claude
+ * Desktop. This is the one place that knows what goes in it.
+ *
+ * It replaces three separate implementations that had drifted apart:
+ *
+ *   - release.yml ran `python -m mcpb build`, but `mcpb` is in neither
+ *     requirements.txt nor requirements-dev.txt, so the step failed and took
+ *     the whole release job — including the GitHub Release — down with it.
+ *   - on-demand-release.yml zipped a file list inline that omitted
+ *     `dashboard_api/`, which sports_mcp_server.py imports at runtime.
+ *   - build.sh had the complete list, and was the only one that was right.
+ *
+ * Every payload is validated before it ships: the manifest version has to match
+ * package.json, the declared entry point has to exist, and every asset the
+ * manifest references has to be present.
+ */
+
+import { execFileSync, spawnSync } from "node:child_process";
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  realpathSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import path from "node:path";
+import { fileURLToPath, pathToFileURL } from "node:url";
+
+const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
+const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
+const MCP_DIR = path.join(ROOT_DIR, "mcp");
+const RELEASE_SCRIPT = path.join(SCRIPT_DIR, "release.mjs");
+
+const PACKAGE_NAME = "sports-data-mcp";
+
+// ---------------------------------------------------------------------------
+// Payload
+// ---------------------------------------------------------------------------
+
+/**
+ * What goes into the bundle. `required` files fail the build when missing;
+ * optional ones are skipped with a note, because some (LICENSE) are simply not
+ * in the repo yet.
+ */
+export const PAYLOAD_FILES = [
+  { name: "manifest.json", required: true },
+  { name: "sports_mcp_server.py", required: true },
+  { name: "dashboard_mcp_server.py", required: true },
+  { name: "mcpb_bootstrap.py", required: true },
+  { name: "setup.py", required: true },
+  { name: "requirements.txt", required: true },
+  // Declared by manifest.json as the extension icon — Claude Desktop reads it
+  // out of the bundle, so shipping without it leaves a dangling reference.
+  { name: "icon.png", required: true },
+  { name: ".env.example", required: false },
+  { name: "INSTALL_INSTRUCTIONS.md", required: false },
+  { name: "README.md", required: false },
+  { name: "LICENSE", required: false },
+];
+
+/**
+ * Python packages copied wholesale. `dashboard_api` is not optional despite
+ * being an optional *feature*: sports_mcp_server.py imports it at module load
+ * and only registers its tools when DASHBOARD_API_KEY is set, so omitting it
+ * from the bundle breaks the server outright rather than disabling a feature.
+ */
+export const PAYLOAD_PACKAGES = ["sports_api", "dashboard_api"];
+
+/** Never ship compiled Python or test caches. */
+const EXCLUDED_DIRS = new Set(["__pycache__", ".pytest_cache", ".mypy_cache"]);
+const EXCLUDED_SUFFIXES = [".pyc", ".pyo"];
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+export class McpbError extends Error {}
+
+function fail(message) {
+  throw new McpbError(message);
+}
+
+function printUsage() {
+  console.log(
+    `
+Usage:
+  npm run mcpb                    Package the version in mcp/package.json
+  npm run mcpb -- --dry-run       List the payload, write nothing
+  npm run mcpb -- --json          Emit the result as JSON
+
+Options:
+  --version <v>       Package as this version instead of reading the manifest
+  --from-tag <tag>    Take the version from a release tag (e.g. mcp-v1.1.0)
+  --out-dir <dir>     Where to write the .mcpb (default: mcp/releases)
+  --dry-run           Report the payload and the output path, write nothing
+  --json              Emit {version, path, size, entries} as JSON
+  --help, -h          Show this message
+
+Output:
+  mcp/releases/${PACKAGE_NAME}-v<version>.mcpb
+`.trim()
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+export function parseArgs(args) {
+  const parsed = {
+    version: null,
+    fromTag: null,
+    outDir: null,
+    dryRun: false,
+    json: false,
+    help: false,
+  };
+
+  const takeValue = (flag, inlineValue, nextValue) => {
+    if (inlineValue !== undefined) {
+      if (!inlineValue) {
+        fail(`Missing value after ${flag}.`);
+      }
+      return { value: inlineValue, consumed: 0 };
+    }
+
+    if (!nextValue) {
+      fail(`Missing value after ${flag}.`);
+    }
+
+    return { value: nextValue, consumed: 1 };
+  };
+
+  for (let i = 0; i < args.length; i += 1) {
+    const arg = args[i];
+    const [flag, inlineValue] =
+      arg.startsWith("--") && arg.includes("=")
+        ? [arg.slice(0, arg.indexOf("=")), arg.slice(arg.indexOf("=") + 1)]
+        : [arg, undefined];
+
+    const valued = { "--version": "version", "--from-tag": "fromTag", "--out-dir": "outDir" };
+
+    if (Object.hasOwn(valued, flag)) {
+      const { value, consumed } = takeValue(flag, inlineValue, args[i + 1]);
+      parsed[valued[flag]] = value;
+      i += consumed;
+      continue;
+    }
+
+    switch (flag) {
+      case "--help":
+      case "-h":
+        parsed.help = true;
+        continue;
+      case "--dry-run":
+        parsed.dryRun = true;
+        continue;
+      case "--json":
+        parsed.json = true;
+        continue;
+      default:
+        fail(`Unknown argument "${arg}". Run with --help for usage.`);
+    }
+  }
+
+  if (parsed.version && parsed.fromTag) {
+    fail("--version and --from-tag both set the version. Pick one.");
+  }
+
+  return parsed;
+}
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+export function mcpbFileName(version) {
+  return `${PACKAGE_NAME}-v${version}.mcpb`;
+}
+
+/**
+ * Everything that has to hold before a bundle is worth shipping. Returns all
+ * problems at once rather than stopping at the first.
+ *
+ * `exists` answers "is this name in the staged payload" so the check runs
+ * against what will actually be in the zip, not against the source tree.
+ */
+export function validatePayload({ manifest, packageVersion, exists }) {
+  const problems = [];
+
+  if (!manifest || typeof manifest !== "object") {
+    return ["mcp/manifest.json is missing or is not an object."];
+  }
+
+  if (!manifest.version) {
+    problems.push("mcp/manifest.json has no version.");
+  } else if (packageVersion && manifest.version !== packageVersion) {
+    // bump-version.mjs keeps these in sync; a mismatch means something wrote
+    // one without the other, and Claude Desktop would report the manifest's.
+    problems.push(
+      `Version mismatch: manifest.json says ${manifest.version}, package.json says ${packageVersion}. Run the bump script.`
+    );
+  }
+
+  const entryPoint = manifest.server?.entry_point;
+
+  if (!entryPoint) {
+    problems.push("mcp/manifest.json declares no server.entry_point.");
+  } else if (!exists(entryPoint)) {
+    problems.push(`Entry point "${entryPoint}" is declared in the manifest but not in the payload.`);
+  }
+
+  if (manifest.icon && !exists(manifest.icon)) {
+    problems.push(`Icon "${manifest.icon}" is declared in the manifest but not in the payload.`);
+  }
+
+  return problems;
+}
+
+// ---------------------------------------------------------------------------
+// Staging
+// ---------------------------------------------------------------------------
+
+function shouldSkip(sourcePath) {
+  const base = path.basename(sourcePath);
+
+  if (EXCLUDED_DIRS.has(base)) {
+    return true;
+  }
+
+  return EXCLUDED_SUFFIXES.some((suffix) => base.endsWith(suffix));
+}
+
+/** Copy the payload into a clean staging directory; returns the names staged. */
+function stagePayload(stageDir, { dryRun }) {
+  const staged = [];
+  const skipped = [];
+
+  if (!dryRun) {
+    rmSync(stageDir, { recursive: true, force: true });
+    mkdirSync(stageDir, { recursive: true });
+  }
+
+  for (const { name, required } of PAYLOAD_FILES) {
+    const source = path.join(MCP_DIR, name);
+
+    if (!existsSync(source)) {
+      if (required) {
+        fail(`Required file mcp/${name} is missing — refusing to ship an incomplete bundle.`);
+      }
+
+      skipped.push(name);
+      continue;
+    }
+
+    if (!dryRun) {
+      cpSync(source, path.join(stageDir, name));
+    }
+
+    staged.push(name);
+  }
+
+  for (const pkg of PAYLOAD_PACKAGES) {
+    const source = path.join(MCP_DIR, pkg);
+
+    if (!existsSync(source) || !statSync(source).isDirectory()) {
+      fail(`Required package mcp/${pkg}/ is missing — the server would not import.`);
+    }
+
+    if (!dryRun) {
+      cpSync(source, path.join(stageDir, pkg), {
+        recursive: true,
+        filter: (src) => !shouldSkip(src),
+      });
+    }
+
+    staged.push(`${pkg}/`);
+  }
+
+  return { staged, skipped };
+}
+
+// ---------------------------------------------------------------------------
+// Zipping
+// ---------------------------------------------------------------------------
+
+/**
+ * The archiver to use. `zip` on macOS/Linux and on GitHub's runners;
+ * Compress-Archive is the Windows fallback. Node has no zip writer built in and
+ * this toolchain takes no dependencies, so shelling out to a battle-tested
+ * archiver beats hand-rolling the container format for a file Claude Desktop
+ * has to be able to open.
+ */
+export function pickArchiver({ has = (tool) => spawnSync(tool, ["--version"], { stdio: "ignore" }).status === 0 } = {}) {
+  if (has("zip")) {
+    return "zip";
+  }
+
+  if (process.platform === "win32" && has("powershell")) {
+    return "powershell";
+  }
+
+  return null;
+}
+
+export function archiveCommand(archiver, { outPath }) {
+  if (archiver === "zip") {
+    // -r recurse, -9 max compression, -X drop platform extras so the archive is
+    // reproducible, and belt-and-braces excludes for anything that slipped in.
+    return ["zip", ["-r", "-9", "-X", "-q", outPath, ".", "-x", "*/__pycache__/*", "-x", "*.pyc"]];
+  }
+
+  if (archiver === "powershell") {
+    return [
+      "powershell",
+      ["-NoProfile", "-Command", `Compress-Archive -Path * -DestinationPath '${outPath}' -Force`],
+    ];
+  }
+
+  fail(`Unsupported archiver "${archiver}".`);
+}
+
+/** Read the archive back and list its entries, so a broken zip fails here. */
+function verifyArchive(outPath) {
+  const result = spawnSync("unzip", ["-l", outPath], { encoding: "utf8" });
+
+  if (result.status !== 0) {
+    // unzip is not everywhere; absence is not evidence of a bad archive.
+    return null;
+  }
+
+  const entries = result.stdout
+    .split("\n")
+    .map((line) => line.match(/^\s+\d+\s+\S+\s+\S+\s+(.+)$/)?.[1])
+    .filter((name) => name && name !== "Name");
+
+  if (!entries.includes("manifest.json")) {
+    fail(`The built bundle has no manifest.json at its root — Claude Desktop would reject it.`);
+  }
+
+  return entries;
+}
+
+// ---------------------------------------------------------------------------
+// Version resolution
+// ---------------------------------------------------------------------------
+
+function readJson(absPath) {
+  return JSON.parse(readFileSync(absPath, "utf8"));
+}
+
+function resolveVersion(args) {
+  if (args.version) {
+    return args.version;
+  }
+
+  if (args.fromTag) {
+    const output = execFileSync(process.execPath, [RELEASE_SCRIPT, "--from-tag", args.fromTag, "--json"], {
+      cwd: ROOT_DIR,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+    });
+
+    const plan = JSON.parse(output);
+    const mcp = plan.packages.find((pkg) => pkg.key === "mcp");
+
+    if (!mcp) {
+      fail(`Tag ${args.fromTag} does not cover the mcp package.`);
+    }
+
+    return mcp.nextVersion ?? mcp.currentVersion;
+  }
+
+  return readJson(path.join(MCP_DIR, "package.json")).version;
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+function main() {
+  const args = parseArgs(process.argv.slice(2));
+
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  if (!existsSync(MCP_DIR)) {
+    fail("mcp/ does not exist.");
+  }
+
+  const version = resolveVersion(args);
+  const packageVersion = readJson(path.join(MCP_DIR, "package.json")).version;
+  const manifest = readJson(path.join(MCP_DIR, "manifest.json"));
+
+  const stageDir = path.join(MCP_DIR, "build", PACKAGE_NAME);
+  const outDir = args.outDir ? path.resolve(ROOT_DIR, args.outDir) : path.join(MCP_DIR, "releases");
+  const outPath = path.join(outDir, mcpbFileName(version));
+
+  const log = args.json ? () => {} : console.log;
+
+  log(`📦 MCPB package\n`);
+  log(`   version : ${version}`);
+  log(`   output  : ${path.relative(ROOT_DIR, outPath)}`);
+
+  const { staged, skipped } = stagePayload(stageDir, { dryRun: args.dryRun });
+
+  // Validate against what was staged, not against mcp/ — that is what ships.
+  const stagedNames = new Set(staged.map((name) => name.replace(/\/$/, "")));
+  const problems = validatePayload({
+    manifest,
+    packageVersion: args.version ? null : packageVersion,
+    exists: (name) => stagedNames.has(name),
+  });
+
+  if (problems.length > 0) {
+    console.error("❌ Refusing to build an invalid bundle:");
+    problems.forEach((problem) => console.error(`   • ${problem}`));
+    process.exitCode = 1;
+    return;
+  }
+
+  log(`\n   Payload (${staged.length}):`);
+  staged.forEach((name) => log(`     ${name}`));
+
+  if (skipped.length > 0) {
+    log(`\n   Not present, skipped: ${skipped.join(", ")}`);
+  }
+
+  if (args.dryRun) {
+    log("\n📋 Dry run — nothing written.");
+
+    if (args.json) {
+      console.log(JSON.stringify({ version, path: path.relative(ROOT_DIR, outPath), dryRun: true, payload: staged }, null, 2));
+    }
+
+    return;
+  }
+
+  const archiver = pickArchiver();
+
+  if (!archiver) {
+    fail("No archiver found. Install `zip` (macOS/Linux) — it is what builds the .mcpb.");
+  }
+
+  mkdirSync(outDir, { recursive: true });
+  rmSync(outPath, { force: true });
+
+  const [command, commandArgs] = archiveCommand(archiver, { outPath });
+  const result = spawnSync(command, commandArgs, { cwd: stageDir, stdio: "inherit" });
+
+  if (result.status !== 0) {
+    fail(`${command} failed while building the bundle.`);
+  }
+
+  const entries = verifyArchive(outPath);
+  const sizeKb = Math.round(statSync(outPath).size / 1024);
+
+  log(`\n✅ Built ${path.relative(ROOT_DIR, outPath)} (${sizeKb} KB${entries ? `, ${entries.length} entries` : ""})`);
+
+  // CI reads this to attach the file to the GitHub Release.
+  if (process.env.GITHUB_OUTPUT) {
+    writeFileSync(
+      process.env.GITHUB_OUTPUT,
+      `path=${path.relative(ROOT_DIR, outPath)}\nversion=${version}\nsize_kb=${sizeKb}\n`,
+      { flag: "a" }
+    );
+  }
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        { version, path: path.relative(ROOT_DIR, outPath), sizeKb, entries: entries?.length ?? null, payload: staged },
+        null,
+        2
+      )
+    );
+  }
+}
+
+function isInvokedDirectly() {
+  if (!process.argv[1]) {
+    return false;
+  }
+
+  try {
+    return pathToFileURL(realpathSync(process.argv[1])).href === import.meta.url;
+  } catch {
+    return false;
+  }
+}
+
+if (isInvokedDirectly()) {
+  try {
+    main();
+  } catch (error) {
+    if (error instanceof McpbError) {
+      console.error(`❌ Error: ${error.message}`);
+    } else {
+      console.error("❌ Fatal error:", error.message);
+    }
+
+    process.exit(1);
+  }
+}

--- a/scripts/build-mcpb.test.mjs
+++ b/scripts/build-mcpb.test.mjs
@@ -1,0 +1,419 @@
+/**
+ * Tests for MCPB packaging.
+ *
+ * Run with: npm run test:mcpb  (from dashboard/), or
+ * `node --test scripts/*.test.mjs`.
+ *
+ * The end-to-end test builds a real .mcpb from a fixture tree and reads the
+ * archive back, because the failure that matters here is a bundle that is
+ * missing something Claude Desktop needs.
+ */
+
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { after, describe, it } from "node:test";
+import { fileURLToPath } from "node:url";
+
+import {
+  McpbError,
+  PAYLOAD_FILES,
+  PAYLOAD_PACKAGES,
+  archiveCommand,
+  mcpbFileName,
+  parseArgs,
+  pickArchiver,
+  validatePayload,
+} from "./build-mcpb.mjs";
+
+const SCRIPTS_DIR = fileURLToPath(new URL(".", import.meta.url));
+
+// ---------------------------------------------------------------------------
+// Payload definition
+// ---------------------------------------------------------------------------
+
+describe("payload definition", () => {
+  it("requires the files the server cannot start without", () => {
+    const required = PAYLOAD_FILES.filter((f) => f.required).map((f) => f.name);
+
+    assert.ok(required.includes("manifest.json"));
+    assert.ok(required.includes("sports_mcp_server.py"));
+    assert.ok(required.includes("requirements.txt"));
+  });
+
+  it("ships dashboard_api, which the server imports at load time", () => {
+    // The inline list in on-demand-release.yml omitted this, producing bundles
+    // whose entry point could not import.
+    assert.ok(PAYLOAD_PACKAGES.includes("dashboard_api"));
+    assert.ok(PAYLOAD_PACKAGES.includes("sports_api"));
+  });
+
+  it("ships the icon the manifest declares", () => {
+    const icon = PAYLOAD_FILES.find((f) => f.name === "icon.png");
+    assert.ok(icon, "icon.png must be in the payload");
+    assert.equal(icon.required, true);
+  });
+
+  it("treats files that are not in the repo yet as optional", () => {
+    assert.equal(PAYLOAD_FILES.find((f) => f.name === "LICENSE").required, false);
+  });
+});
+
+describe("mcpbFileName", () => {
+  it("matches the name the release workflows attach", () => {
+    assert.equal(mcpbFileName("1.0.1"), "sports-data-mcp-v1.0.1.mcpb");
+    assert.equal(mcpbFileName("2.0.0"), "sports-data-mcp-v2.0.0.mcpb");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Validation
+// ---------------------------------------------------------------------------
+
+describe("validatePayload", () => {
+  const manifest = {
+    version: "1.0.1",
+    icon: "icon.png",
+    server: { entry_point: "sports_mcp_server.py" },
+  };
+  const present = new Set(["manifest.json", "sports_mcp_server.py", "icon.png"]);
+  const check = (overrides = {}, exists = (n) => present.has(n)) =>
+    validatePayload({ manifest, packageVersion: "1.0.1", exists, ...overrides });
+
+  it("passes a complete, in-sync payload", () => {
+    assert.deepEqual(check(), []);
+  });
+
+  it("catches a manifest/package version desync", () => {
+    const problems = check({ packageVersion: "1.0.2" });
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /manifest\.json says 1\.0\.1, package\.json says 1\.0\.2/);
+  });
+
+  it("skips the version check when the version was given explicitly", () => {
+    assert.deepEqual(check({ packageVersion: null }), []);
+  });
+
+  it("catches an entry point that is not in the bundle", () => {
+    const problems = check({}, (n) => n !== "sports_mcp_server.py" && present.has(n));
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /Entry point "sports_mcp_server\.py"/);
+  });
+
+  it("catches an icon the manifest references but the bundle lacks", () => {
+    // Exactly the defect in every bundle shipped so far.
+    const problems = check({}, (n) => n !== "icon.png" && present.has(n));
+    assert.equal(problems.length, 1);
+    assert.match(problems[0], /Icon "icon\.png"/);
+  });
+
+  it("does not demand an icon when the manifest declares none", () => {
+    assert.deepEqual(check({ manifest: { ...manifest, icon: undefined } }), []);
+  });
+
+  it("reports a manifest with no version or entry point", () => {
+    const problems = check({ manifest: { server: {} } });
+    assert.equal(problems.length, 2);
+  });
+
+  it("handles a missing manifest without throwing", () => {
+    assert.equal(validatePayload({ manifest: null, packageVersion: "1.0.0", exists: () => true }).length, 1);
+  });
+
+  it("reports every problem at once", () => {
+    const problems = validatePayload({
+      manifest: { version: "9.9.9", icon: "icon.png", server: { entry_point: "missing.py" } },
+      packageVersion: "1.0.1",
+      exists: () => false,
+    });
+    assert.equal(problems.length, 3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Argument parsing
+// ---------------------------------------------------------------------------
+
+describe("parseArgs", () => {
+  it("defaults to reading the version from the manifest", () => {
+    const args = parseArgs([]);
+    assert.equal(args.version, null);
+    assert.equal(args.fromTag, null);
+    assert.equal(args.dryRun, false);
+  });
+
+  it("parses valued flags in both spellings", () => {
+    assert.equal(parseArgs(["--version", "1.2.3"]).version, "1.2.3");
+    assert.equal(parseArgs(["--version=1.2.3"]).version, "1.2.3");
+    assert.equal(parseArgs(["--from-tag", "mcp-v1.1.0"]).fromTag, "mcp-v1.1.0");
+    assert.equal(parseArgs(["--out-dir", "/tmp/out"]).outDir, "/tmp/out");
+  });
+
+  it("parses the switches", () => {
+    assert.equal(parseArgs(["--dry-run"]).dryRun, true);
+    assert.equal(parseArgs(["--json"]).json, true);
+    assert.equal(parseArgs(["--help"]).help, true);
+  });
+
+  it("rejects two conflicting version sources", () => {
+    assert.throws(() => parseArgs(["--version", "1.0.0", "--from-tag", "mcp-v1.1.0"]), McpbError);
+  });
+
+  it("rejects missing values and unknown flags", () => {
+    assert.throws(() => parseArgs(["--version"]), McpbError);
+    assert.throws(() => parseArgs(["--nonsense"]), McpbError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Archiver
+// ---------------------------------------------------------------------------
+
+describe("pickArchiver", () => {
+  it("prefers zip when it is available", () => {
+    assert.equal(pickArchiver({ has: () => true }), "zip");
+  });
+
+  it("returns null when nothing can archive, rather than guessing", () => {
+    assert.equal(pickArchiver({ has: () => false }), null);
+  });
+});
+
+describe("archiveCommand", () => {
+  it("zips the staging directory's contents, not the directory itself", () => {
+    const [command, args] = archiveCommand("zip", { outPath: "/out/pkg.mcpb" });
+
+    assert.equal(command, "zip");
+    assert.equal(args.at(args.indexOf("/out/pkg.mcpb") + 1), ".", "archives the cwd contents");
+    assert.ok(args.includes("-r"));
+  });
+
+  it("excludes compiled Python belt-and-braces", () => {
+    const [, args] = archiveCommand("zip", { outPath: "/out/pkg.mcpb" });
+    assert.ok(args.includes("*/__pycache__/*"));
+    assert.ok(args.includes("*.pyc"));
+  });
+
+  it("rejects an archiver it does not know", () => {
+    assert.throws(() => archiveCommand("tar", { outPath: "/out/pkg.mcpb" }), McpbError);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// End to end
+// ---------------------------------------------------------------------------
+
+const fixtures = [];
+
+after(() => {
+  for (const dir of fixtures) {
+    rmSync(dir, { recursive: true, force: true });
+  }
+});
+
+/** A minimal mcp/ tree with the script installed alongside it. */
+function createFixture({ manifest, packageVersion = "1.0.1" } = {}) {
+  const root = mkdtempSync(path.join(tmpdir(), "bettrack-mcpb-"));
+  fixtures.push(root);
+
+  const write = (relPath, content) => {
+    const abs = path.join(root, relPath);
+    mkdirSync(path.dirname(abs), { recursive: true });
+    writeFileSync(abs, content, "utf8");
+  };
+
+  write("mcp/package.json", JSON.stringify({ name: "sports-data-mcp", version: packageVersion }, null, 2));
+  write(
+    "mcp/manifest.json",
+    JSON.stringify(
+      manifest ?? {
+        name: "sports-data-mcp",
+        version: packageVersion,
+        icon: "icon.png",
+        server: { entry_point: "sports_mcp_server.py" },
+      },
+      null,
+      2
+    )
+  );
+
+  for (const name of ["sports_mcp_server.py", "dashboard_mcp_server.py", "mcpb_bootstrap.py", "setup.py"]) {
+    write(`mcp/${name}`, `# ${name}\n`);
+  }
+  write("mcp/requirements.txt", "aiohttp>=3.9.0\n");
+  write("mcp/icon.png", "not really a png\n");
+  write("mcp/.env.example", "ODDS_API_KEY=\n");
+  write("mcp/INSTALL_INSTRUCTIONS.md", "# Install\n");
+
+  write("mcp/sports_api/__init__.py", "");
+  write("mcp/sports_api/tools.py", "# tools\n");
+  write("mcp/dashboard_api/__init__.py", "");
+  // Should be excluded from the bundle.
+  write("mcp/sports_api/__pycache__/tools.cpython-311.pyc", "compiled");
+  write("mcp/sports_api/stale.pyc", "compiled");
+
+  mkdirSync(path.join(root, "scripts"), { recursive: true });
+  cpSync(path.join(SCRIPTS_DIR, "build-mcpb.mjs"), path.join(root, "scripts", "build-mcpb.mjs"));
+
+  return root;
+}
+
+function runMcpb(root, args = []) {
+  return execFileSync("node", [path.join(root, "scripts", "build-mcpb.mjs"), ...args], {
+    cwd: root,
+    encoding: "utf8",
+    stdio: ["ignore", "pipe", "pipe"],
+  });
+}
+
+function entriesOf(archivePath) {
+  return execFileSync("unzip", ["-Z1", archivePath], { encoding: "utf8" }).split("\n").filter(Boolean);
+}
+
+describe("build-mcpb CLI (end to end)", () => {
+  it("builds an archive named for the manifest version", () => {
+    const root = createFixture();
+    runMcpb(root);
+
+    const out = path.join(root, "mcp/releases/sports-data-mcp-v1.0.1.mcpb");
+    assert.ok(existsSync(out), "the .mcpb was written");
+  });
+
+  it("includes every payload file and package", () => {
+    const root = createFixture();
+    runMcpb(root);
+
+    const entries = entriesOf(path.join(root, "mcp/releases/sports-data-mcp-v1.0.1.mcpb"));
+
+    for (const name of ["manifest.json", "sports_mcp_server.py", "requirements.txt", "icon.png"]) {
+      assert.ok(entries.includes(name), `${name} is in the bundle`);
+    }
+    assert.ok(entries.some((e) => e.startsWith("sports_api/")), "sports_api ships");
+    assert.ok(entries.some((e) => e.startsWith("dashboard_api/")), "dashboard_api ships");
+  });
+
+  it("excludes compiled Python", () => {
+    const root = createFixture();
+    runMcpb(root);
+
+    const entries = entriesOf(path.join(root, "mcp/releases/sports-data-mcp-v1.0.1.mcpb"));
+    assert.deepEqual(entries.filter((e) => e.includes("__pycache__") || e.endsWith(".pyc")), []);
+  });
+
+  it("puts manifest.json at the archive root, where Claude Desktop looks", () => {
+    const root = createFixture();
+    runMcpb(root);
+
+    const entries = entriesOf(path.join(root, "mcp/releases/sports-data-mcp-v1.0.1.mcpb"));
+    assert.ok(entries.includes("manifest.json"), "not nested under a directory");
+  });
+
+  it("writes nothing in dry-run mode", () => {
+    const root = createFixture();
+    const output = runMcpb(root, ["--dry-run"]);
+
+    assert.match(output, /Dry run — nothing written/);
+    assert.ok(!existsSync(path.join(root, "mcp/releases")));
+  });
+
+  it("reports the result as JSON", () => {
+    const root = createFixture();
+    const output = runMcpb(root, ["--json"]);
+    const result = JSON.parse(output.slice(output.lastIndexOf("{")));
+
+    assert.equal(result.version, "1.0.1");
+    assert.match(result.path, /sports-data-mcp-v1\.0\.1\.mcpb$/);
+    assert.ok(result.sizeKb >= 0);
+    assert.ok(result.entries > 0);
+  });
+
+  it("refuses to build when manifest and package versions disagree", () => {
+    const root = createFixture({
+      manifest: { version: "9.9.9", server: { entry_point: "sports_mcp_server.py" } },
+    });
+
+    assert.throws(
+      () => runMcpb(root),
+      (error) => {
+        assert.equal(error.status, 1);
+        assert.match(error.stdout + error.stderr, /Version mismatch/);
+        return true;
+      }
+    );
+
+    assert.ok(!existsSync(path.join(root, "mcp/releases")), "nothing was written");
+  });
+
+  it("refuses to build when the manifest points at a missing entry point", () => {
+    const root = createFixture({
+      manifest: { version: "1.0.1", server: { entry_point: "not_shipped.py" } },
+    });
+
+    assert.throws(
+      () => runMcpb(root),
+      (error) => {
+        assert.match(error.stdout + error.stderr, /Entry point "not_shipped\.py"/);
+        return true;
+      }
+    );
+  });
+
+  it("refuses to build when a required file is missing", () => {
+    const root = createFixture();
+    rmSync(path.join(root, "mcp/requirements.txt"));
+
+    assert.throws(
+      () => runMcpb(root),
+      (error) => {
+        assert.match(error.stdout + error.stderr, /Required file mcp\/requirements\.txt is missing/);
+        return true;
+      }
+    );
+  });
+
+  it("refuses to build when a required package is missing", () => {
+    const root = createFixture();
+    rmSync(path.join(root, "mcp/dashboard_api"), { recursive: true });
+
+    assert.throws(
+      () => runMcpb(root),
+      (error) => {
+        assert.match(error.stdout + error.stderr, /Required package mcp\/dashboard_api\//);
+        return true;
+      }
+    );
+  });
+
+  it("honors an explicit --version without demanding manifest agreement", () => {
+    const root = createFixture();
+    runMcpb(root, ["--version", "2.0.0"]);
+
+    assert.ok(existsSync(path.join(root, "mcp/releases/sports-data-mcp-v2.0.0.mcpb")));
+  });
+
+  it("writes to --out-dir when asked", () => {
+    const root = createFixture();
+    runMcpb(root, ["--out-dir", "dist-mcpb"]);
+
+    assert.ok(existsSync(path.join(root, "dist-mcpb/sports-data-mcp-v1.0.1.mcpb")));
+  });
+
+  it("emits the path for CI to attach to the release", () => {
+    const root = createFixture();
+    const outputFile = path.join(root, "gh-output.txt");
+    writeFileSync(outputFile, "", "utf8");
+
+    execFileSync("node", [path.join(root, "scripts", "build-mcpb.mjs")], {
+      cwd: root,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "pipe"],
+      env: { ...process.env, GITHUB_OUTPUT: outputFile },
+    });
+
+    const emitted = readFileSync(outputFile, "utf8");
+    assert.match(emitted, /path=mcp\/releases\/sports-data-mcp-v1\.0\.1\.mcpb/);
+    assert.match(emitted, /version=1\.0\.1/);
+  });
+});

--- a/scripts/build.sh
+++ b/scripts/build.sh
@@ -284,73 +284,17 @@ bump_component_versions() {
 # ---------------------------------------------------------------------------
 build_mcpb() {
     local version="$1"
+    # Payload definition, validation and zipping live in scripts/build-mcpb.mjs
+    # so the workflows, build.sh and the release script all ship the same bundle.
     log_info "Building MCPB package for version $version..."
 
-    mkdir -p "$BUILD_DIR"
-
-    # Validate dependencies (non-fatal; packages are bundled via requirements.txt for end-users)
-    log_info "Checking Python dependencies..."
-    if "$PYTHON" -m pip install --dry-run -r "$MCP_ROOT/requirements.txt" -q \
-           --break-system-packages 2>/dev/null; then
-        log_ok "Dependencies satisfied"
-    else
-        log_warn "Could not verify dependencies (may be an externally-managed env) — continuing"
+    if ! command -v node &>/dev/null; then
+        log_error "Node.js not found — required to build the MCPB"
+        exit 1
     fi
 
-    # Stage files
-    local pkg_dir="$BUILD_DIR/sports-data-mcp"
-    rm -rf "$pkg_dir"
-    mkdir -p "$pkg_dir"
-
-    local files=(
-        "sports_mcp_server.py"
-        "dashboard_mcp_server.py"
-        "manifest.json"
-        "requirements.txt"
-        "mcpb_bootstrap.py"
-        "setup.py"
-        "LICENSE"
-        ".env.example"
-        "INSTALL_INSTRUCTIONS.md"
-    )
-    for f in "${files[@]}"; do
-        local src="$MCP_ROOT/$f"
-        if [[ -f "$src" ]]; then
-            cp "$src" "$pkg_dir/"
-            log_info "  copied: $f"
-        fi
-    done
-
-    # Copy Python packages (no __pycache__ / .pyc)
-    # dashboard_api ships unconditionally: sports_mcp_server.py imports it and
-    # registers the dashboard tools at runtime only when DASHBOARD_API_KEY is
-    # set, so omitting it here would break the optional dashboard integration.
-    local packages=(
-        "sports_api"
-        "dashboard_api"
-    )
-    for pkg in "${packages[@]}"; do
-        if [[ -d "$MCP_ROOT/$pkg" ]]; then
-            cp -r "$MCP_ROOT/$pkg" "$pkg_dir/$pkg"
-            find "$pkg_dir/$pkg" -type d -name "__pycache__" -exec rm -rf {} + 2>/dev/null || true
-            find "$pkg_dir/$pkg" -name "*.pyc" -delete 2>/dev/null || true
-            log_info "  copied: $pkg/"
-        else
-            log_warn "  MISSING package: $pkg/ (package will be incomplete)"
-        fi
-    done
-
-    # Create .mcpb (ZIP)
-    mkdir -p "$RELEASES_DIR"
-    local mcpb_path="$RELEASES_DIR/sports-data-mcp-v${version}.mcpb"
-    rm -f "$mcpb_path"
-
-    (cd "$pkg_dir" && zip -r -9 "$mcpb_path" . -x "*/__pycache__/*" -x "*.pyc" > /dev/null)
-
-    local size_kb
-    size_kb=$(du -k "$mcpb_path" | cut -f1)
-    log_ok "MCPB package created: $mcpb_path (${size_kb} KB)"
-    MCPB_PATH="$mcpb_path"
+    node "$SCRIPT_DIR/build-mcpb.mjs" --version "$version"
+    MCPB_PATH="$RELEASES_DIR/sports-data-mcp-v${version}.mcpb"
 }
 
 # ---------------------------------------------------------------------------

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -32,6 +32,7 @@ import { extractUnreleasedSection, getTodayDate } from "./bump-version.mjs";
 const SCRIPT_DIR = path.dirname(fileURLToPath(import.meta.url));
 const ROOT_DIR = path.resolve(SCRIPT_DIR, "..");
 const BUMP_SCRIPT = path.join(SCRIPT_DIR, "bump-version.mjs");
+const MCPB_SCRIPT = path.join(SCRIPT_DIR, "build-mcpb.mjs");
 const ROOT_CHANGELOG = path.join(ROOT_DIR, "CHANGELOG.md");
 
 const DEFAULT_BRANCH = "main";
@@ -650,6 +651,28 @@ function applyBump(packageKeys, level) {
   runNode([BUMP_SCRIPT, ...targets, "--no-input"], { capture: false });
 }
 
+/**
+ * The MCPB is a zip of the MCP server payload — no registry, no credentials —
+ * so a release that ships one can build it right here, after the bump has put
+ * the new version into manifest.json. CI attaches the file this returns rather
+ * than rebuilding it with its own file list.
+ */
+function buildMcpb(plan) {
+  if (!plan.artifacts.includes("mcpb")) {
+    return null;
+  }
+
+  const output = runNode([MCPB_SCRIPT, "--json"]);
+
+  try {
+    // --json still prints the human report first; the JSON object is last.
+    const start = output.lastIndexOf("{");
+    return JSON.parse(output.slice(start));
+  } catch {
+    fail(`Could not read the MCPB build result:\n${output}`);
+  }
+}
+
 function writeRootChangelog(plan) {
   if (!existsSync(ROOT_CHANGELOG)) {
     return false;
@@ -698,7 +721,7 @@ function commitAndTag(plan, { allowDirty = false } = {}) {
   runGit(["tag", "-a", plan.tag, "-m", `Release ${plan.tag}`]);
 }
 
-function emitCiOutputs(plan) {
+function emitCiOutputs(plan, mcpb) {
   const outputPath = process.env.GITHUB_OUTPUT;
 
   if (!outputPath) {
@@ -718,6 +741,11 @@ function emitCiOutputs(plan) {
 
   for (const artifact of plan.artifacts) {
     lines.push(`build_${artifact.replace(/-/g, "_")}=true`);
+  }
+
+  if (mcpb) {
+    lines.push(`mcpb_path=${mcpb.path}`);
+    lines.push(`mcpb_version=${mcpb.version}`);
   }
 
   const notes = renderReleaseNotes({ tag: plan.tag, entries: plan.entries, projectNotes: plan.projectNotes });
@@ -782,6 +810,10 @@ async function main() {
   }
 
   if (args.dryRun) {
+    if (plan.artifacts.includes("mcpb")) {
+      console.log("\n   Would package: mcp/releases/sports-data-mcp-v<new version>.mcpb");
+    }
+
     console.log("\n📋 Dry run — nothing written. Release notes would be:\n");
     console.log(
       renderReleaseNotes({ tag: plan.tag, entries: plan.entries, projectNotes: plan.projectNotes })
@@ -803,6 +835,14 @@ async function main() {
   console.log("\n📦 Bumping versions...");
   applyBump(plan.scope.packages, args.bump);
 
+  let mcpb = null;
+
+  if (plan.artifacts.includes("mcpb")) {
+    console.log("\n📦 Packaging the MCPB...");
+    mcpb = buildMcpb(plan);
+    console.log(`   ✅ ${mcpb.path} (${mcpb.sizeKb} KB)`);
+  }
+
   console.log("\n📝 Updating root CHANGELOG.md...");
   console.log(writeRootChangelog(plan) ? "   ✅ Updated" : "   ⏭️  Skipped (no [Unreleased] section)");
 
@@ -810,7 +850,7 @@ async function main() {
   commitAndTag(plan, { allowDirty: args.allowDirty });
   console.log(`   ✅ ${plan.tag}`);
 
-  emitCiOutputs(plan);
+  emitCiOutputs(plan, mcpb);
 
   if (!args.push) {
     console.log("\n💡 Push when ready:");

--- a/scripts/release.test.mjs
+++ b/scripts/release.test.mjs
@@ -9,7 +9,7 @@
 
 import assert from "node:assert/strict";
 import { execFileSync } from "node:child_process";
-import { cpSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
+import { cpSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from "node:fs";
 import { tmpdir } from "node:os";
 import path from "node:path";
 import { after, describe, it } from "node:test";
@@ -443,7 +443,6 @@ function createFixtureRepo({ changelogs = {}, rootChangelog } = {}) {
 
   const manifests = {
     "mcp/package.json": { name: "sports-data-mcp", version: "1.0.0" },
-    "mcp/manifest.json": { name: "sports-data-mcp", version: "1.0.0" },
     "dashboard/package.json": { name: "sports-betting-dashboard", version: "0.3.0" },
     "dashboard/backend/package.json": { name: "@wford26/bettrack-backend", version: "0.5.0" },
     "dashboard/frontend/package.json": { name: "@wford26/bettrack-frontend", version: "0.6.0" },
@@ -458,12 +457,26 @@ function createFixtureRepo({ changelogs = {}, rootChangelog } = {}) {
   }
 
   write("CHANGELOG.md", rootChangelog ?? changelog("\n- A project-wide note\n"));
-  write("mcp/server.py", "print('mcp')\n");
+
+  // The MCPB payload, so a release whose scope includes mcp really packages one.
+  write("mcp/manifest.json", JSON.stringify({
+    name: "sports-data-mcp",
+    version: "1.0.0",
+    icon: "icon.png",
+    server: { entry_point: "sports_mcp_server.py" },
+  }, null, 2));
+  for (const name of ["sports_mcp_server.py", "dashboard_mcp_server.py", "mcpb_bootstrap.py", "setup.py"]) {
+    write(`mcp/${name}`, `# ${name}\n`);
+  }
+  write("mcp/requirements.txt", "aiohttp>=3.9.0\n");
+  write("mcp/icon.png", "png\n");
+  write("mcp/sports_api/__init__.py", "");
+  write("mcp/dashboard_api/__init__.py", "");
   write("dashboard/backend/src/index.ts", "export const backend = 1;\n");
   write("dashboard/frontend/src/main.tsx", "export const frontend = 1;\n");
 
   mkdirSync(path.join(root, "scripts"), { recursive: true });
-  for (const file of ["bump-version.mjs", "release.mjs"]) {
+  for (const file of ["bump-version.mjs", "release.mjs", "build-mcpb.mjs"]) {
     cpSync(path.join(SCRIPTS_DIR, file), path.join(root, "scripts", file));
   }
 
@@ -580,6 +593,28 @@ describe("release CLI (end to end)", () => {
     const message = execFileSync("git", ["log", "-1", "--pretty=%B"], { cwd: root, encoding: "utf8" });
     assert.match(message, /chore\(release\)/);
     assert.match(message, /mcp: v1\.1\.0/);
+  });
+
+  it("packages the MCPB as part of a release that ships one", () => {
+    const root = createFixtureRepo();
+    const output = runRelease(root, ["mcp", "--skip-preflight"]);
+
+    // The bundle must carry the *bumped* version, which means it is built after
+    // the bump rather than from whatever the manifest said beforehand.
+    const bundle = path.join(root, "mcp/releases/sports-data-mcp-v1.0.1.mcpb");
+    assert.ok(existsSync(bundle), "the .mcpb exists");
+    assert.match(output, /Packaging the MCPB/);
+
+    const entries = execFileSync("unzip", ["-Z1", bundle], { encoding: "utf8" }).split("\n").filter(Boolean);
+    assert.ok(entries.includes("manifest.json"));
+    assert.ok(entries.some((e) => e.startsWith("dashboard_api/")), "dashboard_api ships");
+  });
+
+  it("does not package an MCPB for a dashboard-only release", () => {
+    const root = createFixtureRepo();
+    runRelease(root, ["backend", "--skip-preflight"]);
+
+    assert.ok(!existsSync(path.join(root, "mcp/releases")), "no bundle for a scope without mcpb");
   });
 
   it("does not push unless asked", () => {


### PR DESCRIPTION
## Why

The `2026.08.18` tag was pushed but **no GitHub Release appeared**. Root cause:

```
/opt/hostedtoolcache/Python/3.11.15/x64/bin/python: No module named mcpb
```

`release.yml`'s `Build MCP Server` step ran `python -m mcpb build`, but `mcpb` is in neither `requirements.txt` nor `requirements-dev.txt`. That step sits *before* `Create GitHub Release`, so the job died and the Release was never created — the tag appeared and nothing else did. (Run [32214105936](https://github.com/WFord26/BetTrack/actions/runs/32214105936).)

The last successful release, `2026.8.16`, came from `on-demand-release.yml`, which zips the bundle by hand — a different code path, so it survived.

## What changed

### `scripts/build-mcpb.mjs` (new)

One place that knows the MCPB payload, replacing three implementations that had drifted apart:

| Where | Problem |
|-------|---------|
| `release.yml` | `python -m mcpb build` — dependency not installed, killed the release job |
| `on-demand-release.yml` | inline zip that **omitted `dashboard_api/`** |
| `build.sh` | correct — now delegates like everything else |

`release.mjs` calls it after the bump, so the bundle always carries the version just written into `manifest.json`.

```bash
npm run release -- mcp     # bumps, packages the .mcpb, commits, tags
npm run mcpb               # just the bundle
npm run mcpb:dry           # list the payload, write nothing
```

### Two further defects this surfaced

- **`dashboard_api/` was missing from bundles built by `on-demand-release.yml`.** `sports_mcp_server.py` imports it at module load — it only *registers* its tools conditionally — so those bundles were missing a package the server needs to start.
- **Every bundle shipped so far declared `"icon": "icon.png"` without including the file.** Verified against `sports-data-mcp-v0.4.4.mcpb`. The payload now carries it.

### Validation

Bundles are checked before they're written, reporting all problems at once:

- `manifest.json` version matches `package.json` (a desync means something wrote one without the other, and Claude Desktop reports the manifest's)
- the declared `server.entry_point` is in the payload
- every asset the manifest references is in the payload
- required files and both Python packages are present
- the finished archive is read back and must have `manifest.json` at its root

`__pycache__/` and `*.pyc` never ship.

### Secret Scan fix

Gitleaks was failing on the release commit. It flags the 64-char SHA-256 digests in `.bump-hashes.json` as high-entropy secrets, so **every** version bump commit would fail the scan. Allowlisted in `.gitleaks.toml` with a note explaining why.

## Testing

- **213 tests pass** across all four script suites (`npm run test:scripts`)
- 37 new tests for MCPB packaging: payload definition, validation rules, archiver selection, plus end-to-end runs that build a real `.mcpb` from a fixture tree and read the archive back
- 2 new release integration tests asserting a `mcp`-scoped release produces the bundle at the *bumped* version, and that a `backend`-scoped one produces none
- CI now runs `node scripts/build-mcpb.mjs` in `test.yml` — the check that would have caught this before it reached a release
- Verified by hand against the real repo: 30 entries, 186 KB, icon and `dashboard_api` present, no compiled Python

## Reviewer notes

- **`2026.08.18` still has no Release.** Re-running the failed run won't help — GitHub takes the workflow file from the tag's own tree, which still has the broken step. Options: move the tag to a commit carrying this fix and force-push (cleanest, nothing consumed the tag), run `on-demand-release.yml` to cut `2026.08.18.1`, or publish manually with `gh release create` using the bundle already at `mcp/releases/sports-data-mcp-v1.0.1.mcpb`.
- `LICENSE` is listed as an optional payload file and is currently skipped — there is no `mcp/LICENSE` in the repo. Worth adding separately.
- `build.sh`'s `build_mcpb()` lost ~60 lines to delegation; its behaviour is unchanged apart from now shipping `icon.png`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)